### PR TITLE
Calendar duration incorrect when creating a new booking

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -250,7 +250,7 @@ function booking_update_options($optionvalues){
 			$event->eventtype    = 'booking';
 			$event->timestart    = $option->coursestarttime;
 			$event->visible      = instance_is_visible('booking', $option);
-            $event->timeduration = $option->courseendtime - $option->coursestarttime;
+			$event->timeduration = $option->courseendtime - $option->coursestarttime;
 
 			$tmpEvent = calendar_event::create($event);
 			$option->calendarid = $tmpEvent->id;

--- a/lib.php
+++ b/lib.php
@@ -250,7 +250,7 @@ function booking_update_options($optionvalues){
 			$event->eventtype    = 'booking';
 			$event->timestart    = $option->coursestarttime;
 			$event->visible      = instance_is_visible('booking', $option);
-			$event->timeduration = $option->courseendtime;
+            $event->timeduration = $option->courseendtime - $option->coursestarttime;
 
 			$tmpEvent = calendar_event::create($event);
 			$option->calendarid = $tmpEvent->id;


### PR DESCRIPTION
Hi David,

I found an issue when creating a new booking with start and end times selected and the "Add to calendar" option checked off. The calendar entries were being given astronomical time durations because of line 253 in lib.php. This little patch appears to have fixed the issue. I'm using Moodle 2.7, by the way.
