### PR TITLE
fix externallib unit-testing fail

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 defined('MOODLE_INTERNAL') || die();
-ini_set('max_execution_time', 600);
+core_php_time_limit::raise(600);
 
 require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . "/externallib.php");


### PR DESCRIPTION
When running `vendor/bin/phpunit "core_externallib_testcase" lib/tests/externallib_test.php`
This line causes a PHPUnit testing failure
`There was 1 error:

1) core_externallib_testcase::test_all_external_info with data set "mod_booking_bookings" (stdClass Object (...))
Warning: max_execution_time was changed to 600`

To resolve it, this kind of command will resolve the error message, just like:
https://github.com/moodle/moodle/blob/master/lib/cronlib.php#L51
And perhaps also consider:
https://github.com/moodle/moodle/blob/master/lib/cronlib.php#L55