### PR TITLE
Usi behat2

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1226,12 +1226,18 @@ function booking_update_options($optionvalues, $context) {
 
         // Save relation for each newly created optiondate if checkbox is active.
         save_entity_relations_for_optiondates_of_option($optionvalues, $optionid);
-
-        // Trigger an event that booking option has been updated.
-        $event = \mod_booking\event\bookingoption_updated::create(array('context' => $context, 'objectid' => $optionid,
-                'userid' => $USER->id));
-        $event->trigger();
-
+        
+        // Trigger an event that booking option has been updated - only if it is NOT a template.
+        if (!isset($optionvalues->addastemplate) || $optionvalues->addastemplate == 0) {
+            $event = \mod_booking\event\bookingoption_updated::create(
+                array(
+                    'context' => $context,
+                    'objectid' => $optionid,
+                    'userid' => $USER->id
+                )
+            );
+            $event->trigger();
+        }
         // Finally, we need to check if any existing booking rules are affected.
         if ($option->bookingid != 0) {
             rules_info::execute_rules_for_option($optionid);

--- a/tests/behat/booking_add_option.feature
+++ b/tests/behat/booking_add_option.feature
@@ -48,17 +48,18 @@ Feature: In a booking instance create booking options
            | Booking option name | Test option - Webinar |
         And I set the field "startendtimeknown" to "checked"
         And I set the field "addtocalendar" to "1"
+        And I wait "2" seconds
         And I set the following fields to these values:
-            | coursestarttime[day] | 31 |
-            | coursestarttime[month] | December |
-            | coursestarttime[year] | 2021 |
-            | coursestarttime[hour] | 09 |
-            | coursestarttime[minute] | 00|
+            | coursestarttime[day] | 1 |
+            | coursestarttime[month] | January |
+            | coursestarttime[year] | ##yesterday##%Y## |
+            | coursestarttime[hour] | 00 |
+            | coursestarttime[minute] | 00 |
         And I set the following fields to these values:
-            | courseendtime[day] | 31 |
-            | courseendtime[month] | December |
-            | courseendtime[year] | 2022 |
-            | courseendtime[hour] | 09 |
+            | courseendtime[day] | 1 |
+            | courseendtime[month] | January |
+            | courseendtime[year] | ## + 1 year ## %Y ## |
+            | courseendtime[hour] | 00 |
             | courseendtime[minute] | 00 |
         And I press "Save and go back"
         And I should see "Book now"

--- a/tests/behat/booking_create_template.feature
+++ b/tests/behat/booking_create_template.feature
@@ -36,15 +36,15 @@ Feature: In a booking create
         Then I click on "Start and end time of course are known" "checkbox"
         Then I set the field "Add to course calendar" to "Add to calendar (visible only to course participants)"
         And I set the following fields to these values:
-            | coursestarttime[day] | 31 |
-            | coursestarttime[month] | December |
-            | coursestarttime[year] | 2022 |
+            | coursestarttime[day] | ##tomorrow##%d## |
+            | coursestarttime[month] | ##tomorrow##%B## |
+            | coursestarttime[year] | ##tomorrow##%Y## |
             | coursestarttime[hour] | 09 |
             | coursestarttime[minute] | 00|
         And I set the following fields to these values:
-            | courseendtime[day] | 31 |
-            | courseendtime[month] | December |
-            | courseendtime[year] | 2023 |
+            | courseendtime[day] | ##tomorrow##%d## |
+            | courseendtime[month] | ##tomorrow##%B## |
+            | courseendtime[year] | ## + 1 year ## %Y ## |
             | courseendtime[hour] | 09 |
             | courseendtime[minute] | 00 |
         Then I set the field "Add as template" to "Use as global template"

--- a/tests/behat/booking_multisessions.feature
+++ b/tests/behat/booking_multisessions.feature
@@ -33,25 +33,29 @@ Feature: In a booking create multi session options
         And I should see "New option"
         And I click on "Book now" "button"
         And I click on "Continue" "button"
-        ## And I follow "Settings"
         And I click on "Settings" "icon"
         And I follow "Duplicate this booking option"
         And I press "Save and go back"
-        ## And I follow "Settings"
-        And I click on "Settings" "icon"
-        ## And I follow "Multiple dates session"
-        And I follow "Manage option dates"
+        ## And I click on "Settings" "icon"
+        And I click on "#mod_booking_all_options_r1_c3 .dropdown .icon" "css_element"
+        ## And I follow "Manage option dates"
+        And I click on ".dropdown-menu.show .fa-calendar-check-o" "css_element"
         And I set the following fields to these values:
             | Day | 30 |
             | Month | January |
-            | Year | 2023 |
+            | Year | ## + 1 year ## %Y ## |
             | Hour | 12 |
             | Minute | 00 |
             | endhour | 20 |
             | endminute | 00 |
         And I press "Save"
         And I press "Back"
-        And I should see "Monday, 30 January 2023, 12:00 PM - 8:00 PM"
+        And I should see "New option - Webinar - Copy"
+        And I click on "#mod_booking_all_options_r1_c1 .fa-calendar" "css_element"
+        And I wait "1" seconds
+        Then I should see "## +1 year ##%Y##" in the "#mod_booking_all_options_r1_c1" "css_element"
+        And I should see "30 January" in the "#mod_booking_all_options_r1_c1" "css_element"
+        And I should see "12:00 PM - 8:00 PM" in the "#mod_booking_all_options_r1_c1" "css_element"
 
     @javascript
     Scenario: Send reminder mail to participant
@@ -122,9 +126,14 @@ Feature: In a booking create multi session options
         And I click on "Send reminder e-mail" "button"
         And I should see "Notification e-mail has been sent!"
 
+    @javascript
     Scenario: Run cron
-        Then I open the link "webserver/admin/cron.php"
-        And I wait "1" seconds
+        Given I log in as "admin1"
+        And I wait "2" seconds
+        Then I trigger cron
+        And I wait "2" seconds
+        And I run all adhoc tasks
+        And I wait "2" seconds
 
     @javascript @email
     Scenario: Send email for user

--- a/tests/behat/booking_multisessions.feature
+++ b/tests/behat/booking_multisessions.feature
@@ -62,14 +62,14 @@ Feature: In a booking create multi session options
         Given I log in as "teacher1"
         When I am on "Course 1" course homepage
         And I follow "My booking"
-        ## And I press "dropdown d-inline show"
         And I click on "Settings" "icon"
-        And I follow "Edit teachers"
-        And I press "Turn editing on"
-        And I click on "Teacher 1 (teacher1@example.com)" "text"
-        And I click on "Add" "button"
+        And I follow "Edit this booking option"
+        And I wait "1" seconds
+        And I press "Teachers"
+        And I wait "1" seconds
+        And I set the field "Teachers" to "Teacher 1 (teacher1@example.com)"
+        And I press "Save and go back"
         And I follow "My booking"
-        ## And I follow "Settings"
         And I click on "Settings" "icon"
         And I follow "Book other users"
         And I click on "Student 1 (student1@example.com)" "text"
@@ -115,7 +115,6 @@ Feature: In a booking create multi session options
         When I am on "Course 1" course homepage
         Then I follow "My booking"
         And I follow "My booking"
-        ## And I follow "Settings"
         And I click on "Settings" "icon"
         And I follow "Book other users"
         And I click on "Student 1 (student1@example.com)" "text"
@@ -129,11 +128,10 @@ Feature: In a booking create multi session options
     @javascript
     Scenario: Run cron
         Given I log in as "admin1"
-        And I wait "2" seconds
         Then I trigger cron
-        And I wait "2" seconds
+        And I wait "10" seconds
         And I run all adhoc tasks
-        And I wait "2" seconds
+        And I wait "10" seconds
 
     @javascript @email
     Scenario: Send email for user


### PR DESCRIPTION
Fixed 3 scenarios by using relative dates
Scenario: Create booking option and see it on activity page - use relative dates (form yesterday up to +1 year)
Scenario: Create session with multiple dates (relative date - next January)
Scenario: Add booking template by using relative dates (from tomorrow and up to + 1 year)
And
Fix for booking_update_options() function - trigger an event that booking option has been updated only if it is NOT a template - to prevent error caused by event observer.
