### PR TITLE
Replaced textual invisibility with fontawesome icon

### DIFF
--- a/lang/en/booking.php
+++ b/lang/en/booking.php
@@ -1139,7 +1139,7 @@ $string['optionvisibility'] = 'Visibility';
 $string['optionvisibility_help'] = 'Here you can choose whether the option should be visible for everyone or if it should be hidden from normal users and be visible to entitled users only.';
 $string['optionvisible'] = 'Visible to everyone (default)';
 $string['optioninvisible'] = 'Hide from normal users (visible to entitled users only)';
-$string['invisibleoption'] = 'Invisible booking option';
+$string['invisibleoption'] = '<i class="fa fa-eye-slash" aria-hidden="true"></i>';
 $string['optionannotation'] = 'Internal annotation';
 $string['optionannotation_help'] = 'Add internal remarks, annotations or anything you want. It will only be shown in this form and nowhere else.';
 $string['optionidentifier'] = 'Unique identifier';


### PR DESCRIPTION
Like described and discussed in Userstory MUSI-236, the way the invisibility is indicated has been altered.