### PR TITLE
Fix privacy provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -126,6 +126,46 @@ class provider implements
             'privacy:metadata:booking_userevents'
         );
 
+        $collection->add_database_table(
+            'booking_optiondates_teachers',
+            [
+                'optiondateid' => 'privacy:metadata:booking_optiondates_teachers:optiondateid',
+                'userid' => 'privacy:metadata:booking_optiondates_teachers:userid',
+            ],
+            'privacy:metadata:booking_optiondates_teachers'
+        );
+
+        $collection->add_database_table(
+            'booking_subbooking_answers',
+            [
+                'itemid' => 'privacy:metadata:booking_subbooking_answers:itemid',
+                'optionid' => 'privacy:metadata:booking_subbooking_answers:optionid',
+                'sboptionid' => 'privacy:metadata:booking_subbooking_answers:sboptionid',
+                'userid' => 'privacy:metadata:booking_subbooking_answers:userid',
+                'usermodified' => 'privacy:metadata:booking_subbooking_answers:usermodified',
+                'json' => 'privacy:metadata:booking_subbooking_answers:json',
+                'timestart' => 'privacy:metadata:booking_subbooking_answers:timestart',
+                'timeend' => 'privacy:metadata:booking_subbooking_answers:timeend',
+                'status' => 'privacy:metadata:booking_subbooking_answers:status',
+                'timecreated' => 'privacy:metadata:booking_subbooking_answers:timecreated',
+                'timemodified' => 'privacy:metadata:booking_subbooking_answers:timemodified',
+            ],
+            'privacy:metadata:booking_subbooking_answers'
+        );
+
+        $collection->add_database_table(
+            'booking_odt_deductions',
+            [
+                'optiondateid' => 'privacy:metadata:booking_odt_deductions:optiondateid',
+                'userid' => 'privacy:metadata:booking_odt_deductions:userid',
+                'reason' => 'privacy:metadata:booking_odt_deductions:reason',
+                'usermodified' => 'privacy:metadata:booking_odt_deductions:usermodified',
+                'timecreated' => 'privacy:metadata:booking_odt_deductions:timecreated',
+                'timemodified' => 'privacy:metadata:booking_odt_deductions:timemodified',
+            ],
+            'privacy:metadata:booking_odt_deductions'
+        );
+
         return $collection;
     }
 

--- a/lang/en/booking.php
+++ b/lang/en/booking.php
@@ -1789,6 +1789,31 @@ $string['privacy:metadata:booking_userevents:optionid'] = 'ID of booking option 
 $string['privacy:metadata:booking_userevents:optiondateid'] = 'ID of optiondate (session) for user event';
 $string['privacy:metadata:booking_userevents:eventid'] = 'ID of event in events table';
 
+$string['privacy:metadata:booking_optiondates_teachers'] = 'Track teachers for each session.';
+$string['privacy:metadata:booking_optiondates_teachers:optiondateid'] = 'ID of the option date';
+$string['privacy:metadata:booking_optiondates_teachers:userid'] = 'The userid of the teacher.';
+
+$string['privacy:metadata:booking_subbooking_answers'] = 'Stores the anwers (the bookings) of a user for a particular subbooking.';
+$string['privacy:metadata:booking_subbooking_answers:itemid'] = 'itemid can be the same as sboptionid, but there are some types (eg. timeslots which provide slots) where one sboptionid provides a lot of itemids.';
+$string['privacy:metadata:booking_subbooking_answers:optionid'] = 'The option ID';
+$string['privacy:metadata:booking_subbooking_answers:sboptionid'] = 'id of the booked subbooking';
+$string['privacy:metadata:booking_subbooking_answers:userid'] = 'Userid of the booked user.';
+$string['privacy:metadata:booking_subbooking_answers:usermodified'] = 'The user that modified';
+$string['privacy:metadata:booking_subbooking_answers:json'] = 'supplementary data if necessary';
+$string['privacy:metadata:booking_subbooking_answers:timestart'] = 'Timestamp for start time of this booking';
+$string['privacy:metadata:booking_subbooking_answers:timeend'] = 'Timestamp for end time of this booking';
+$string['privacy:metadata:booking_subbooking_answers:status'] = 'The bookings status, as in booked, waiting list, in the shopping cart, on a notify list or deleted';
+$string['privacy:metadata:booking_subbooking_answers:timecreated'] = 'The time created';
+$string['privacy:metadata:booking_subbooking_answers:timemodified'] = 'The time last modified';
+
+$string['privacy:metadata:booking_odt_deductions'] = 'This table is used to log if we want to deduct a part of a teachers salary if (s)he has missing hours.';
+$string['privacy:metadata:booking_odt_deductions:optiondateid'] = 'The option date ID';
+$string['privacy:metadata:booking_odt_deductions:userid'] = 'Userid of the teacher who gets a deduction for this option date.';
+$string['privacy:metadata:booking_odt_deductions:reason'] = 'Reason for the deduction.';
+$string['privacy:metadata:booking_odt_deductions:usermodified'] = 'The user that modified';
+$string['privacy:metadata:booking_odt_deductions:timecreated'] = 'The time created';
+$string['privacy:metadata:booking_odt_deductions:timemodified'] = 'The time last modified';
+
 // Calendar.php.
 $string['usercalendarentry'] = 'You are booked for <a href="{$a}">this session</a>.';
 $string['bookingoptioncalendarentry'] = '<a href="{$a}" class="btn btn-primary">Book now...</a>';


### PR DESCRIPTION
I noticed some errors when running unit tests for the plugin:

Before fix:
```
1) core_privacy\privacy\provider_test::test_table_coverage
The following tables with user fields must be covered with metadata providers: 
  - booking_optiondates_teachers (userid)
  - booking_subbooking_answers (usermodified, userid)
  - booking_odt_deductions (usermodified, userid)
 ```
