### PR TITLE
Fix undefined constant BEHAT_SITE_RUNNING

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -29,7 +29,7 @@
 function xmldb_booking_install() {
     global $DB;
      // Check if the table exists before inserting.
-    if (!PHPUNIT_TEST && !BEHAT_SITE_RUNNING && $DB->get_manager()->table_exists('booking_pricecategories')) {
+    if (!PHPUNIT_TEST && !defined('BEHAT_SITE_RUNNING') && $DB->get_manager()->table_exists('booking_pricecategories')) {
         // Check if a default category already exists.
         if (!$DB->record_exists('booking_pricecategories', ['identifier' => 'default'])) {
             // Define the default price category.


### PR DESCRIPTION
The `BEHAT_SITE_RUNNING` constant was being used without a defined check, resulting in an `Undefined constant "BEHAT_SITE_RUNNING"` exception during installation.

This replaces the constant with constant defined check.

```
-->mod_booking
++ install.xml: Success (1.13 seconds) ++
Default exception handler: Exception - Undefined constant "BEHAT_SITE_RUNNING" Debug: 
Error code: generalexceptionmessage
* line 32 of /mod/booking/db/install.php: Error thrown
* line 897 of /lib/upgradelib.php: call to xmldb_booking_install()
* line 657 of /lib/upgradelib.php: call to upgrade_plugins_modules()
* line 1943 of /lib/upgradelib.php: call to upgrade_plugins()
* line 436 of /lib/installlib.php: call to upgrade_noncore()
* line 197 of /admin/cli/install_database.php: call to install_cli_database()

!!! Exception - Undefined constant "BEHAT_SITE_RUNNING" !!!
!! 
Error code: generalexceptionmessage !!
!! Stack trace: * line 32 of /mod/booking/db/install.php: Error thrown
* line 897 of /lib/upgradelib.php: call to xmldb_booking_install()
* line 657 of /lib/upgradelib.php: call to upgrade_plugins_modules()
* line 1943 of /lib/upgradelib.php: call to upgrade_plugins()
* line 436 of /lib/installlib.php: call to upgrade_noncore()
* line 197 of /admin/cli/install_database.php: call to install_cli_database()
 !!
exit status 1
```