### PR TITLE
Added missing string

### DIFF
--- a/lang/en/booking.php
+++ b/lang/en/booking.php
@@ -2544,6 +2544,7 @@ $string['subject'] = 'Subject';
 $string['submitandadd'] = 'Add a new booking option';
 $string['submitandgoback'] = 'Close this form';
 $string['submitandstay'] = 'Stay here';
+$string['subplugintype_bookingextension'] = 'Booking extension';
 $string['subplugintype_bookingextension_plural'] = 'Booking extensions';
 $string['subscribersto'] = 'Teachers for \'{$a}\'';
 $string['subscribetocourse'] = 'Enrol users in the course';


### PR DESCRIPTION
To resolve error:

Invalid get_string() identifier: 'subplugintype_bookingextension' or component 'mod_booking'. Perhaps you are missing $string['subplugintype_bookingextension'] = ''; in mod/booking/lang/en/booking.php?
line 356 of /lib/classes/string_manager_standard.php: call to debugging()
line 7013 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
line 624 of /lib/classes/plugin_manager.php: call to get_string()
line 130 of /admin/tool/installaddon/classes/installer.php: call to core\plugin_manager->plugintype_name()
line 54 of /admin/tool/installaddon/classes/installfromzip_form.php: call to tool_installaddon_installer->get_plugin_types_menu()
line 217 of /lib/formslib.php: call to tool_installaddon_installfromzip_form->definition()
line 100 of /admin/tool/installaddon/classes/installer.php: call to moodleform->__construct()
line 93 of /admin/tool/installaddon/index.php: call to tool_installaddon_installer->get_installfromzip_form()