### PR TITLE
1216 sorting changes on booking the options

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -3,12 +3,90 @@ name: Moodle Plugin CI
 on: [push, pull_request]
 
 jobs:
-  moodle405to501:
+  moodle500to501:
     uses: Wunderbyte-GmbH/catalyst-moodle-workflows/.github/workflows/ci.yml@main
     with:
       # Change these based on your plugin's requirements
       disable_release: true  # Use true if using the tag-based release workflow
-      moodle_branches: "MOODLE_405_STABLE MOODLE_500_STABLE MOODLE_501_STABLE"  # Optional: Only test specific Moodle versions
+      moodle_branches: "MOODLE_500_STABLE MOODLE_501_STABLE"  # Optional: Only test specific Moodle versions
+      min_php: '8.2'  # Optional: Set minimum PHP version
+
+      # Command to install more dependencies
+      extra_plugin_runners: |
+        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_wunderbyte_table
+        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_shopping_cart
+        moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_entities
+        moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-customfield_dynamicformat
+        moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-tool_mocktesttime
+        moodle-plugin-ci add-plugin --branch master branchup/moodle-filter_shortcodes
+        moodle-plugin-ci add-plugin --branch MOODLE_500_STABLE moodleworkplace/moodle-tool_certificate
+
+      # If you need to ignore specific paths (third-party libraries are ignored by default)
+      ignore_paths: 'vue3,moodle/tests/fixtures,moodle/Sniffs,moodle/vue3'
+
+      # Specify paths to ignore for mustache lint
+      mustache_ignore_names: 'bookingoption_dates_custom_list_items.mustache,form_booking_options_selector_suggestion.mustache,table_list_container.mustache,optiondatesteacherstable_list.mustache,optiondatesteacherstable_list_row.mustache,optiondatesteacherstable_list_container.mustache,option_collapsible_close.mustache,option_collapsible_open.mustache,static.mustache,advcheckbox.mustache,select.mustache,shorttext.mustache,mobile_details_button.mustache,mobile_mybookings_list.mustache,mobile_booking_option_details.mustache,mobile_view_page.mustache,table_cards_container.mustache'
+
+      # Specify paths to ignore for code checker
+      # codechecker_ignore_paths: 'OpenTBS, TinyButStrong'
+
+      # Specify paths to ignore for PHPDoc checker
+      # phpdocchecker_ignore_paths: 'OpenTBS, TinyButStrong'
+
+      # If you need to disable specific tests
+      # disable_phpcpd: true
+      # disable_mustache: true
+      # disable_phpunit: true
+      # disable_grunt: true
+      # disable_phpdoc: true
+      # disable_phpcs: true
+      # disable_phplint: true
+      # disable_ci_validate: true
+
+      # If you need to enable PHPMD
+      enable_phpmd: true
+
+      # For strict code quality checks
+      codechecker_max_warnings: 0
+
+      # Override to exclude stale AMD file check (similar to your current workaround)
+      workarounds: |
+        # Set additional environment variables
+        # echo "SOME_PATHS=OpenTBS, TinyButStrong" >> $GITHUB_ENV
+
+        # WORKAROUND 17/04/2025: The following code is a workaround for the "File is stale and needs to be rebuilt" error
+        # This occurs when AMD modules import Moodle core dependencies
+        # See issue: https://github.com/moodlehq/moodle-plugin-ci/issues/350
+        # This workaround should be removed once the issue is fixed upstream
+        # Load NVM and use the version from .nvmrc
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+        # Go to moodle directory
+        cd moodle
+
+        # Use NVM to set Node version and ensure grunt-cli is installed
+        nvm use
+        npm install
+        npm install -g grunt-cli
+
+        # Go back to plugin directory
+        cd ../plugin
+
+        # Pre-build AMD files to avoid stale file warnings
+        echo "=== Building AMD files before CI check ==="
+        grunt --gruntfile ../moodle/Gruntfile.js amd
+        echo "AMD files built successfully"
+
+        # Go Back to main directory
+        cd ..
+        # END OF WORKAROUND
+  moodle405:
+    uses: Wunderbyte-GmbH/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    with:
+      # Change these based on your plugin's requirements
+      disable_release: true  # Use true if using the tag-based release workflow
+      moodle_branches: "MOODLE_405_STABLE"  # Optional: Only test specific Moodle versions
       min_php: '8.1'  # Optional: Set minimum PHP version
 
       # Command to install more dependencies

--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -3,17 +3,17 @@ name: Moodle Plugin CI
 on: [push, pull_request]
 
 jobs:
-  moodle500:
+  moodle500to501:
     uses: Wunderbyte-GmbH/catalyst-moodle-workflows/.github/workflows/ci.yml@main
     with:
       # Change these based on your plugin's requirements
       disable_release: true  # Use true if using the tag-based release workflow
-      moodle_branches: "MOODLE_500_STABLE"  # Optional: Only test specific Moodle versions
+      moodle_branches: "MOODLE_500_STABLE MOODLE_501_STABLE"  # Optional: Only test specific Moodle versions
 
       # Command to install more dependencies
       extra_plugin_runners: |
-        moodle-plugin-ci add-plugin --branch MOODLE_401_DEV Wunderbyte-GmbH/moodle-local_wunderbyte_table
-        moodle-plugin-ci add-plugin --branch MOODLE_401_DEV Wunderbyte-GmbH/moodle-local_shopping_cart
+        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_wunderbyte_table
+        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_shopping_cart
         moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_entities
         moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-customfield_dynamicformat
         moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-tool_mocktesttime
@@ -80,18 +80,18 @@ jobs:
         # Go Back to main directory
         cd ..
         # END OF WORKAROUND
-  moodle401to405:
+  moodle405:
     uses: Wunderbyte-GmbH/catalyst-moodle-workflows/.github/workflows/ci.yml@main
     with:
       # Change these based on your plugin's requirements
       disable_release: true  # Use true if using the tag-based release workflow
-      moodle_branches: "MOODLE_401_STABLE MOODLE_404_STABLE MOODLE_405_STABLE"  # Optional: Only test specific Moodle versions
+      moodle_branches: "MOODLE_405_STABLE"  # Optional: Only test specific Moodle versions
       min_php: '7.4'  # Optional: Set minimum PHP version
 
       # Command to install more dependencies
       extra_plugin_runners: |
-        moodle-plugin-ci add-plugin --branch MOODLE_401_DEV Wunderbyte-GmbH/moodle-local_wunderbyte_table
-        moodle-plugin-ci add-plugin --branch MOODLE_401_DEV Wunderbyte-GmbH/moodle-local_shopping_cart
+        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_wunderbyte_table
+        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_shopping_cart
         moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_entities
         moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-customfield_dynamicformat
         moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-tool_mocktesttime

--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -3,90 +3,13 @@ name: Moodle Plugin CI
 on: [push, pull_request]
 
 jobs:
-  moodle500to501:
+  moodle405to501:
     uses: Wunderbyte-GmbH/catalyst-moodle-workflows/.github/workflows/ci.yml@main
     with:
       # Change these based on your plugin's requirements
       disable_release: true  # Use true if using the tag-based release workflow
-      moodle_branches: "MOODLE_500_STABLE MOODLE_501_STABLE"  # Optional: Only test specific Moodle versions
-
-      # Command to install more dependencies
-      extra_plugin_runners: |
-        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_wunderbyte_table
-        moodle-plugin-ci add-plugin --branch MOODLE_405_DEV Wunderbyte-GmbH/moodle-local_shopping_cart
-        moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_entities
-        moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-customfield_dynamicformat
-        moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-tool_mocktesttime
-        moodle-plugin-ci add-plugin --branch master branchup/moodle-filter_shortcodes
-        moodle-plugin-ci add-plugin --branch MOODLE_500_STABLE moodleworkplace/moodle-tool_certificate
-
-      # If you need to ignore specific paths (third-party libraries are ignored by default)
-      ignore_paths: 'vue3,moodle/tests/fixtures,moodle/Sniffs,moodle/vue3'
-
-      # Specify paths to ignore for mustache lint
-      mustache_ignore_names: 'bookingoption_dates_custom_list_items.mustache,form_booking_options_selector_suggestion.mustache,table_list_container.mustache,optiondatesteacherstable_list.mustache,optiondatesteacherstable_list_row.mustache,optiondatesteacherstable_list_container.mustache,option_collapsible_close.mustache,option_collapsible_open.mustache,static.mustache,advcheckbox.mustache,select.mustache,shorttext.mustache,mobile_details_button.mustache,mobile_mybookings_list.mustache,mobile_booking_option_details.mustache,mobile_view_page.mustache,table_cards_container.mustache'
-
-      # Specify paths to ignore for code checker
-      # codechecker_ignore_paths: 'OpenTBS, TinyButStrong'
-
-      # Specify paths to ignore for PHPDoc checker
-      # phpdocchecker_ignore_paths: 'OpenTBS, TinyButStrong'
-
-      # If you need to disable specific tests
-      # disable_phpcpd: true
-      # disable_mustache: true
-      # disable_phpunit: true
-      # disable_grunt: true
-      # disable_phpdoc: true
-      # disable_phpcs: true
-      # disable_phplint: true
-      # disable_ci_validate: true
-
-      # If you need to enable PHPMD
-      enable_phpmd: true
-
-      # For strict code quality checks
-      codechecker_max_warnings: 0
-
-      # Override to exclude stale AMD file check (similar to your current workaround)
-      workarounds: |
-        # Set additional environment variables
-        # echo "SOME_PATHS=OpenTBS, TinyButStrong" >> $GITHUB_ENV
-
-        # WORKAROUND 17/04/2025: The following code is a workaround for the "File is stale and needs to be rebuilt" error
-        # This occurs when AMD modules import Moodle core dependencies
-        # See issue: https://github.com/moodlehq/moodle-plugin-ci/issues/350
-        # This workaround should be removed once the issue is fixed upstream
-        # Load NVM and use the version from .nvmrc
-        export NVM_DIR="$HOME/.nvm"
-        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
-        # Go to moodle directory
-        cd moodle
-
-        # Use NVM to set Node version and ensure grunt-cli is installed
-        nvm use
-        npm install
-        npm install -g grunt-cli
-
-        # Go back to plugin directory
-        cd ../plugin
-
-        # Pre-build AMD files to avoid stale file warnings
-        echo "=== Building AMD files before CI check ==="
-        grunt --gruntfile ../moodle/Gruntfile.js amd
-        echo "AMD files built successfully"
-
-        # Go Back to main directory
-        cd ..
-        # END OF WORKAROUND
-  moodle405:
-    uses: Wunderbyte-GmbH/catalyst-moodle-workflows/.github/workflows/ci.yml@main
-    with:
-      # Change these based on your plugin's requirements
-      disable_release: true  # Use true if using the tag-based release workflow
-      moodle_branches: "MOODLE_405_STABLE"  # Optional: Only test specific Moodle versions
-      min_php: '7.4'  # Optional: Set minimum PHP version
+      moodle_branches: "MOODLE_405_STABLE MOODLE_500_STABLE MOODLE_501_STABLE"  # Optional: Only test specific Moodle versions
+      min_php: '8.1'  # Optional: Set minimum PHP version
 
       # Command to install more dependencies
       extra_plugin_runners: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## Version 9.0.0 (2025120101)
+* Improvement: Now supporting Moodle 4.5+ (skipped support for Moodle 4.1 - 4.4).
+
 ## Version 8.19.0 (2025120100)
 * New feature: Introduce new rule template for adding/removing teachers for option dates.
 * New feature: Add support for selecting custom fields as sortable/filterable fields in wunderbyte_table.

--- a/classes/booking_bookit.php
+++ b/classes/booking_bookit.php
@@ -600,7 +600,7 @@ class booking_bookit {
 
         /** @var renderer $output */
         $output = $PAGE->get_renderer('mod_booking');
-        $data = new bookingoption_description($itemid, null, MOD_BOOKING_DESCRIPTION_WEBSITE, false, null, $user);
+        $data = new bookingoption_description($itemid, null, MOD_BOOKING_DESCRIPTION_CARTITEM, false, null, $user);
         $description = $output->render_bookingoption_description_cartitem($data);
 
         $optiontitle = $bookingoption->option->text;

--- a/classes/booking_rules/actions/send_mail.php
+++ b/classes/booking_rules/actions/send_mail.php
@@ -237,27 +237,6 @@ class send_mail implements booking_rule_action {
 
         $task->set_next_run_time($record->nextruntime);
 
-        // If the same task already exists, don't queue it again.
-        $similartasks = $DB->get_records('task_adhoc', [
-            'nextruntime' => $record->nextruntime,
-            'userid' => $record->userid,
-            ]);
-
-        if (!empty($similartasks)) {
-            foreach ($similartasks as $similartask) {
-                if (!isset($similartask->customdata)) {
-                    continue;
-                }
-                $oldtaskdata = json_decode($similartask->customdata);
-                unset($oldtaskdata->optiondateid);
-                unset($taskdata['optiondateid']);
-                if ($oldtaskdata == (object)$taskdata) {
-                    // A similar task has already been created before, we therefore don't queue the task again.
-                    return;
-                }
-            }
-        }
-
         // Now queue the task or reschedule it.
         \core\task\manager::reschedule_or_queue_adhoc_task($task);
     }

--- a/classes/booking_rules/booking_rule.php
+++ b/classes/booking_rules/booking_rule.php
@@ -96,7 +96,8 @@ interface booking_rule {
      * @param int $optionid
      * @param int $userid
      * @param int $nextruntime
+     * @param int $optiondateid
      * @return bool true if the rule still applies, false if not
      */
-    public function check_if_rule_still_applies(int $optionid, int $userid, int $nextruntime): bool;
+    public function check_if_rule_still_applies(int $optionid, int $userid, int $nextruntime, int $optiondateid = 0): bool;
 }

--- a/classes/booking_rules/rules/rule_react_on_event.php
+++ b/classes/booking_rules/rules/rule_react_on_event.php
@@ -438,9 +438,10 @@ class rule_react_on_event implements booking_rule {
      * @param int $optionid
      * @param int $userid
      * @param int $nextruntime
+     * @param int $optiondateid
      * @return bool true if the rule still applies, false if not
      */
-    public function check_if_rule_still_applies(int $optionid, int $userid, int $nextruntime): bool {
+    public function check_if_rule_still_applies(int $optionid, int $userid, int $nextruntime, int $optiondateid = 0): bool {
 
         if (empty($this->ruleisactive)) {
             return false;

--- a/classes/output/bookingoption_description.php
+++ b/classes/output/bookingoption_description.php
@@ -576,6 +576,17 @@ class bookingoption_description implements renderable, templatable {
                 );
                 break;
 
+            case MOD_BOOKING_DESCRIPTION_CARTITEM:
+                if ($forbookeduser) {
+                    // If it is for booked user, we show a short info text that the option is already booked.
+                    $this->booknowbutton = get_string('infoalreadybooked', 'booking');
+                } else if ($bookinganswers->user_status($user->id) == MOD_BOOKING_STATUSPARAM_WAITINGLIST) {
+                    // If onwaitinglist is 1, we show a short info text that the user is on the waiting list.
+                    // Currently this is only working for the current USER.
+                    $this->booknowbutton = get_string('infowaitinglist', 'booking');
+                }
+                break;
+
             case MOD_BOOKING_DESCRIPTION_CALENDAR:
                 $encodedlink = booking::encode_moodle_url($moodleurl);
                 $this->booknowbutton = "<a href=$encodedlink class='btn btn-primary'>"

--- a/classes/output/view.php
+++ b/classes/output/view.php
@@ -1086,7 +1086,6 @@ class view implements renderable, templatable {
 
         // Check if there are additional customfields included.
         if (!empty($customfieldsinfoarray = shortcodes_handler::get_includecustomfields_info_array($args))) {
-            // $wbtable->define_columns(array_keys($customfieldsinfoarray));
             $wbtable->set_customfields_info_array($customfieldsinfoarray);
         }
 
@@ -1553,7 +1552,6 @@ class view implements renderable, templatable {
         }
         foreach ($customfieldsinfoarray as $cfshortname => $cfinfoarray) {
             if (!empty($cfinfoarray['region'])) {
-                $wbtable->add_classes_to_subcolumns($cfinfoarray['region'], ['columnkeyclass' => 'd-none']);
                 $wbtable->add_subcolumns($cfinfoarray['region'], [$cfshortname]);
                 if (!empty($cfinfoarray['class'])) {
                     $wbtable->add_classes_to_subcolumns(
@@ -1569,6 +1567,7 @@ class view implements renderable, templatable {
                         [$cfshortname]
                     );
                 }
+                $wbtable->add_classes_to_subcolumns($cfinfoarray['region'], ['columnkeyclass' => 'd-none']);
             }
         }
     }

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -282,17 +282,6 @@ class shortcodes {
             self::apply_customfieldfilter($table, $customfieldfilter);
         }
 
-        //         // Temp Info for development purpose.
-        // $table->add_subcolumns('carddurata', ['durata']);
-        // $table->add_subcolumns('cardcompletion', ['completamento']);
-        // $table->add_subcolumns('cardformat', ['formato']);
-        // $table->add_classes_to_subcolumns(
-        //         'carddurata',
-        //         ['columniclassbefore' => 'fa-regular fa-clock'],
-        //         ['durata']
-        //     );
-        // $table->add_subcolumns('cardcompetenze', ['competenze']);
-
         $table->showcountlabel = $showfilter ? true : false;
 
         if (
@@ -773,7 +762,8 @@ class shortcodes {
                     null,
                     [MOD_BOOKING_STATUSPARAM_BOOKED],
                     $additionalwhere,
-                    ""
+                    "",
+                    $table
                 );
 
         $params = array_merge($tempparams, $params);

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -75,6 +75,10 @@ class shortcodes {
     public static function recommendedin($shortcode, $args, $content, $env, $next) {
 
         global $PAGE, $CFG;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if ($error['error'] === 1) {
@@ -126,6 +130,10 @@ class shortcodes {
             $showsearch,
             $showsort,
             false,
+            true,
+            MOD_BOOKING_VIEW_PARAM_LIST,
+            0,
+            $args
         );
 
         // If "rightside" is in the "exclude" array, then we do not show the rightside area (containing the "Book now" button).
@@ -186,6 +194,10 @@ class shortcodes {
     public static function courselist($shortcode, $args, $content, $env, $next) {
 
         global $PAGE, $CFG;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = ['cmid'];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if ($error['error'] === 1) {
@@ -259,7 +271,9 @@ class shortcodes {
             $showsort,
             false,
             $inactivefilter,
-            $viewparam
+            $viewparam,
+            0,
+            $args
         );
 
         // Possibility to add customfieldfilter.
@@ -416,6 +430,10 @@ class shortcodes {
     public static function fieldofstudyoptions($shortcode, $args, $content, $env, $next) {
 
         global $COURSE, $USER, $DB, $CFG;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if (($error['error'] === 1)) {
@@ -489,7 +507,18 @@ class shortcodes {
             $optionsfields = $possibleoptions;
         }
 
-        view::apply_standard_params_for_bookingtable($table, $optionsfields, true, true, true);
+        view::apply_standard_params_for_bookingtable(
+            $table,
+            $optionsfields,
+            true,
+            true,
+            true,
+            true,
+            true,
+            MOD_BOOKING_VIEW_PARAM_LIST,
+            0,
+            $args
+        );
 
         // Set common table options requirelogin, sortorder, sortby.
         self::set_common_table_options_from_arguments($table, $args);
@@ -532,7 +561,11 @@ class shortcodes {
      */
     public static function linkbacktocourse($shortcode, $args, $content, $env, $next) {
 
-        global $COURSE, $USER, $DB, $CFG, $PAGE;
+        global $COURSE, $USER, $DB, $PAGE;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if ($error['error'] === 1) {
@@ -595,6 +628,10 @@ class shortcodes {
      */
     public static function allbookingoptions($shortcode, $args, $content, $env, $next) {
         global $PAGE, $DB, $CFG;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $operator = 'AND';
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
@@ -697,7 +734,9 @@ class shortcodes {
             $showsort,
             false,
             $inactivefilter,
-            $viewparam
+            $viewparam,
+            0,
+            $args
         );
 
         // Possibility to add customfieldfilter.
@@ -776,6 +815,10 @@ class shortcodes {
      */
     public static function mycourselist($shortcode, $args, $content, $env, $next) {
         global $USER, $PAGE, $CFG;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if ($error['error'] === 1) {
@@ -787,7 +830,6 @@ class shortcodes {
         } else {
             $userid = $USER->id;
         }
-        self::fix_args($args);
         $wherearray = [];
         $course = $PAGE->course;
         $perpage = self::check_perpage($args);
@@ -870,6 +912,8 @@ class shortcodes {
             false,
             true,
             $viewparam,
+            0,
+            $args
         );
 
         // Possibility to add customfieldfilter.
@@ -878,7 +922,7 @@ class shortcodes {
             self::apply_customfieldfilter($table, $customfieldfilter);
         }
 
-                $table->showcountlabel = $showfilter ? true : false;
+        $table->showcountlabel = $showfilter ? true : false;
 
         if (
             isset($args['filterontop'])
@@ -947,6 +991,10 @@ class shortcodes {
     public static function fieldofstudycohortoptions($shortcode, $args, $content, $env, $next) {
 
         global $PAGE, $USER, $DB, $CFG;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if ($error['error'] === 1) {
@@ -1026,7 +1074,18 @@ class shortcodes {
             $optionsfields = $possibleoptions;
         }
 
-        view::apply_standard_params_for_bookingtable($table, $optionsfields, true, true, true);
+        view::apply_standard_params_for_bookingtable(
+            $table,
+            $optionsfields,
+            true,
+            true,
+            true,
+            true,
+            true,
+            MOD_BOOKING_VIEW_PARAM_LIST,
+            0,
+            $args
+        );
 
         // Set common table options requirelogin, sortorder, sortby.
         self::set_common_table_options_from_arguments($table, $args);
@@ -1075,7 +1134,11 @@ class shortcodes {
      */
     public static function bulkoperations($shortcode, $args, $content, $env, $next): string {
 
-        global $PAGE, $CFG;
+        global $CFG;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if ($error['error'] === 1) {
@@ -1300,6 +1363,7 @@ class shortcodes {
         if (!empty($customfieldfilter)) {
             self::apply_customfieldfilter($table, $customfieldfilter);
         }
+
         return $filtercolumns;
     }
     /**
@@ -1367,7 +1431,6 @@ class shortcodes {
      * @param array $args
      *
      * @return void
-     *
      */
     public static function set_common_table_options_from_arguments(&$table, $args): void {
         $defaultorder = SORT_ASC; // Default.
@@ -1618,6 +1681,10 @@ class shortcodes {
         global $PAGE;
 
         $requiredargs = [];
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if (
             isset($error['error'])
@@ -1729,8 +1796,11 @@ class shortcodes {
      *
      */
     public static function supervisorteam($shortcode, $args, $content, $env, $next) {
-
         global $PAGE;
+
+        // Get rid of quotation marks.
+        self::fix_args($args);
+
         $requiredargs = [];
         $error = shortcodes_handler::validatecondition($shortcode, $args, true, $requiredargs);
         if (

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -282,6 +282,17 @@ class shortcodes {
             self::apply_customfieldfilter($table, $customfieldfilter);
         }
 
+        //         // Temp Info for development purpose.
+        // $table->add_subcolumns('carddurata', ['durata']);
+        // $table->add_subcolumns('cardcompletion', ['completamento']);
+        // $table->add_subcolumns('cardformat', ['formato']);
+        // $table->add_classes_to_subcolumns(
+        //         'carddurata',
+        //         ['columniclassbefore' => 'fa-regular fa-clock'],
+        //         ['durata']
+        //     );
+        // $table->add_subcolumns('cardcompetenze', ['competenze']);
+
         $table->showcountlabel = $showfilter ? true : false;
 
         if (
@@ -343,7 +354,7 @@ class shortcodes {
      * @return void
      *
      */
-    private static function apply_customfieldfilter(&$table, $args) {
+    public static function apply_customfieldfilter(&$table, $args) {
         if (empty($args)) {
             return;
         }
@@ -376,7 +387,7 @@ class shortcodes {
      * @return array
      *
      */
-    private static function get_columnfilters($args, $verify = true): array {
+    public static function get_columnfilters($args, $verify = true): array {
         if (empty($args)) {
             return [];
         }
@@ -950,7 +961,9 @@ class shortcodes {
                     $wherearray,
                     $userid,
                     $statusarray,
-                    $additionalwhere
+                    $additionalwhere,
+                    '',
+                    $table
                 );
 
         $table->set_filter_sql($fields, $from, $where, $filter, $params);
@@ -1278,7 +1291,7 @@ class shortcodes {
      * @return array
      *
      */
-    private static function apply_bulkoperations_filter(wunderbyte_table &$table, array $columns, array $args) {
+    public static function apply_bulkoperations_filter(wunderbyte_table &$table, array $columns, array $args) {
 
         // Add defined intrange filter. You might need to purge your caches to make this work.
         if (isset($args['intrangefilter'])) {
@@ -1374,7 +1387,7 @@ class shortcodes {
      * @param array $args
      * @return bookingoptions_wbtable
      */
-    private static function init_table_for_courses(
+    public static function init_table_for_courses(
         ?booking $booking = null,
         ?string $uniquetablename = null,
         array $args = []
@@ -1411,7 +1424,7 @@ class shortcodes {
      * @return void
      *
      */
-    private static function apply_bookinginstance_filter(&$table) {
+    public static function apply_bookinginstance_filter(&$table) {
         $bookinginstances = singleton_service::get_all_booking_instances();
 
         $filterarray = [];
@@ -1489,7 +1502,7 @@ class shortcodes {
      * @param array $columnfilters
      * @return string
      */
-    private static function set_customfield_wherearray(
+    public static function set_customfield_wherearray(
         array &$args,
         array &$wherearray,
         array &$tempparamsarray = [],
@@ -1577,7 +1590,7 @@ class shortcodes {
      * @return string
      *
      */
-    private static function set_cmid_wherearray(
+    public static function set_cmid_wherearray(
         array &$args,
         array &$wherearray,
         array &$params = [],
@@ -1623,7 +1636,7 @@ class shortcodes {
      *
      * @return void
      */
-    private static function fix_args(array &$args): void {
+    public static function fix_args(array &$args): void {
         foreach ($args as $key => &$value) {
             // Get rid of quotation marks.
             $value = str_replace('"', '', $value);
@@ -1639,7 +1652,7 @@ class shortcodes {
      * @return int $viewparam if no viewparam is found, the default is MOD_BOOKING_VIEW_PARAM_LIST
      *
      */
-    private static function get_viewparam($args) {
+    public static function get_viewparam($args) {
         // Default is list.
         $viewparam = MOD_BOOKING_VIEW_PARAM_LIST;
         if (!isset($args['type'])) {
@@ -1749,7 +1762,7 @@ class shortcodes {
      * @return void
      *
      */
-    private static function applyallarg($args, &$where) {
+    public static function applyallarg($args, &$where) {
         $startoftoday = strtotime('today'); // Will be 00:00:00 of the current day.
         $selflearncoursesetting = get_config('booking', 'selflearningcoursedisplayinshortcode');
         if (empty($args['all']) || $args['all'] == "false" || $args['all'] == "0") {

--- a/classes/task/send_mail_by_rule_adhoc.php
+++ b/classes/task/send_mail_by_rule_adhoc.php
@@ -121,7 +121,14 @@ class send_mail_by_rule_adhoc extends \core\task\adhoc_task {
             $rule->set_ruledata($ruleinstance);
 
             // We run the call again to see if something has changed (field in bo, in user profile etc.).
-            if (!$rule->check_if_rule_still_applies($taskdata->optionid, $taskdata->userid, $nextruntime)) {
+            if (
+                !$rule->check_if_rule_still_applies(
+                    $taskdata->optionid,
+                    $taskdata->userid,
+                    $nextruntime,
+                    $taskdata->optiondateid ?? 0
+                )
+            ) {
                 mtrace('send_mail_by_rule_adhoc task: Rule does not apply anymore. Mail was NOT SENT for option ' .
                     $taskdata->optionid . ' and user ' . $taskdata->userid);
                 return;

--- a/lib.php
+++ b/lib.php
@@ -71,6 +71,7 @@ define('MOD_BOOKING_DESCRIPTION_ICAL', 3); // Shows link with text "go to bookin
 define('MOD_BOOKING_DESCRIPTION_MAIL', 4); // Shows link with text "go to bookingoption" and meeting links via link.php...
                             // ...for mail placeholder {bookingdetails}.
 define('MOD_BOOKING_DESCRIPTION_OPTIONVIEW', 5); // Description for booking option preview page.
+define('MOD_BOOKING_DESCRIPTION_CARTITEM', 5); // Description for a reduced description we use in bookingbookit.
 
 // Define message parameters.
 define('MOD_BOOKING_MSGPARAM_CONFIRMATION', 1);

--- a/tests/booking_rules/rules_n_days_test.php
+++ b/tests/booking_rules/rules_n_days_test.php
@@ -431,6 +431,12 @@ final class rules_n_days_test extends advanced_testcase {
         // Initially two tasks are scheduled.
         $tasks = \core\task\manager::get_adhoc_tasks('\mod_booking\task\send_mail_by_rule_adhoc');
         $this->assertCount(2, $tasks);
+        $settings = singleton_service::get_instance_of_booking_option_settings($option->id);
+
+        // As we don't run through the set_data functions of the form submissions,...
+        // ... the id of the exisiting option date needs to be set manually.
+        $record->optiondateid_0 = array_keys($settings->sessions)[0];
+        $record->optiondateid_1 = array_keys($settings->sessions)[1];
 
         // Modify booking option based on scenario.
         switch ($updateaction['type']) {
@@ -460,7 +466,6 @@ final class rules_n_days_test extends advanced_testcase {
             default:
                 break;
         }
-        $settings = singleton_service::get_instance_of_booking_option_settings($option->id);
         $record->id = $option->id;
         $record->cmid = $settings->cmid;
         if ($updateaction['type'] !== 'no_change') {

--- a/tests/booking_rules/rules_n_days_test.php
+++ b/tests/booking_rules/rules_n_days_test.php
@@ -26,6 +26,7 @@
 namespace mod_booking;
 
 use advanced_testcase;
+use local_entities_generator;
 use stdClass;
 use mod_booking\booking_rules\rules_info;
 use tool_mocktesttime\time_mock;
@@ -405,6 +406,23 @@ final class rules_n_days_test extends advanced_testcase {
         ];
         $plugingenerator->create_rule($ruledata);
 
+        // Create entities.
+        $entitydata1 = [
+            'name' => 'Entity1',
+            'shortname' => 'entity1',
+            'description' => 'Ent1desc',
+        ];
+        $entitydata2 = [
+            'name' => 'Entity2',
+            'shortname' => 'entity2',
+            'description' => 'Ent2desc',
+        ];
+
+        /** @var local_entities_generator *  $egenerator */
+        $egenerator = self::getDataGenerator()->get_plugin_generator('local_entities');
+        $entityid1 = $egenerator->create_entities($entitydata1);
+        $entityid2 = $egenerator->create_entities($entitydata2);
+
         // Create booking option with two session dates.
         $record = new stdClass();
         $record->bookingid = $booking->id;
@@ -462,6 +480,10 @@ final class rules_n_days_test extends advanced_testcase {
             case 'modify_date':
                 $record->coursestarttime_1 = strtotime('+10 days', time());
                 $record->courseendtime_1 = strtotime('+10 days 2 hours', time());
+                break;
+            case 'modify_location_of_date':
+                $record->local_entities_entityarea_1 = "optiondate";
+                $record->local_entities_entityid_1 = $entityid2; // Option date entity.
                 break;
             default:
                 break;
@@ -563,6 +585,17 @@ final class rules_n_days_test extends advanced_testcase {
                     'contains_prevent' => 'Rule does not apply anymore. Mail was NOT SENT for option',
                     'numberofdatesafterupdate' => 2,
                     'numberoftasks' => 3,
+                ],
+            ],
+            'modify_location_of_date' => [
+                ['type' => 'modify_location_of_date'],
+                [
+                    'messages_sent' => 2,
+                    'messages_prevented' => 0,
+                    'contains_success' => self::MAIL_SUCCES_TRACE,
+                    'contains_prevent' => 'Rule does not apply anymore. Mail was NOT SENT for option',
+                    'numberofdatesafterupdate' => 2,
+                    'numberoftasks' => 2,
                 ],
             ],
         ];

--- a/version.php
+++ b/version.php
@@ -25,12 +25,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025120100;
-$plugin->requires = 2022112800; // Requires this Moodle version. Current: Moodle 4.1.
-$plugin->release = '8.19.0';
+$plugin->version = 2025120101;
+$plugin->requires = 2024100700; // Requires this Moodle version. Current: Moodle 4.5.
+$plugin->release = '9.0.0';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'mod_booking';
 $plugin->supported = [405, 501];
 $plugin->dependencies = [
-    'local_wunderbyte_table' => 2025120100,
+    'local_wunderbyte_table' => 2025120101,
 ];

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@ $plugin->requires = 2022112800; // Requires this Moodle version. Current: Moodle
 $plugin->release = '8.19.0';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'mod_booking';
-$plugin->supported = [401, 405];
+$plugin->supported = [405, 501];
 $plugin->dependencies = [
     'local_wunderbyte_table' => 2025120100,
 ];


### PR DESCRIPTION
During the booking process, we called booking option description with the website. We added there the call to show similar options for each option with a competency. This call set back the sorting order. bookit js calls reloadalltables, we got the table back with the wrong sorting order.
The problem is also that ksw does not show a sorting element. Normally, on search etc, we "read" the sorting from the element and transmit it. so we also mess up sorting of the table via this missing argument.