### PR TITLE
Bugfix: Customfields of type textformat are also supported for certif…

### DIFF
--- a/classes/option/fields/certificate.php
+++ b/classes/option/fields/certificate.php
@@ -298,7 +298,7 @@ class certificate extends field_base {
             $customfielddata = [];
             $customfields = booking_handler::get_customfields();
             foreach ($customfields as $customfield) {
-                if (!in_array($customfield->type, ['text', 'textarea'])) {
+                if (!in_array($customfield->type, ['text', 'textarea', 'textformat'])) {
                     continue;
                 }
                 $placeholder = '{' . $customfield->shortname . '}';


### PR DESCRIPTION
I think this is enough so it's working, but not 100% sure.

to test it: create one customfield of type textformat (wb repository)
Add value to certificate. create certificate, see if value is there.