### PR TITLE
fix for Non-deterministic ordering for tied timemodified values, especially in MariaDB, causes waiting-list selection to vary across runs

### DIFF
--- a/classes/booking_answers/booking_answers.php
+++ b/classes/booking_answers/booking_answers.php
@@ -1322,7 +1322,7 @@ class booking_answers {
             JOIN {booking_options} bo ON ba.optionid = bo.id
             JOIN {user} u ON ba.userid = u.id AND u.deleted = 0
             WHERE $where
-            ORDER BY ba.timemodified ASC";
+            ORDER BY ba.timemodified ASC, ba.id ASC";
 
         return [$sql, $params];
     }

--- a/classes/booking_option.php
+++ b/classes/booking_option.php
@@ -577,7 +577,7 @@ class booking_option {
                    AND u.deleted = 0
                    AND ba.optionid = :optionid
                    AND ba.waitinglist = 0
-              ORDER BY ba.timemodified ASC";
+              ORDER BY ba.timemodified ASC, ba.id ASC";
 
         $params = ["optionid" => $this->optionid];
 
@@ -617,7 +617,7 @@ class booking_option {
                        AND u.id = gm.userid
                        AND gm.groupid $insql
                   GROUP BY u.id
-                  ORDER BY ba.timemodified ASC";
+                  ORDER BY ba.timemodified ASC, ba.id ASC";
             $groupmembers = $DB->get_records_sql($sql, array_merge($params, $inparams));
             $this->bookedusers = array_intersect_key($groupmembers, $this->booking->canbookusers);
             $this->bookedvisibleusers = $this->bookedusers;

--- a/classes/booking_rules/conditions/select_student_in_bo.php
+++ b/classes/booking_rules/conditions/select_student_in_bo.php
@@ -221,7 +221,7 @@ class select_student_in_bo implements booking_rule_condition {
 
         $sql->where .= " AND (ba.waitinglist $operator :borole $anduserid $additionalusers) ";
         // Add sorting in case we use this condition for interval notification.
-        $sql->sort = " ba.timemodified ASC ";
+        $sql->sort = " ba.timemodified ASC, ba.id ASC ";
         $params['borole'] = $borole;
     }
 }


### PR DESCRIPTION
fix for Non-deterministic ordering for tied timemodified values, especially in MariaDB, causes waiting-list selection to vary across runs (https://github.com/Wunderbyte-GmbH/Wunderbyte-GmbH/issues/1087)