### PR TITLE
Bugfix: Correctly check for invisible options

### DIFF
--- a/classes/external/get_booking_option_description.php
+++ b/classes/external/get_booking_option_description.php
@@ -93,7 +93,7 @@ class get_booking_option_description extends external_api {
         $data = new bookingoption_description($optionid, null, MOD_BOOKING_DESCRIPTION_WEBSITE, true, $forbookeduser, $user);
 
         // Fix invisible attribute, by converting to bool.
-        if (isset($data->invisible) && $data->invisible == 1) {
+        if (isset($data->invisible) && $data->invisible == MOD_BOOKING_OPTION_INVISIBLE) {
             $data->invisible = true;
         } else {
             $data->invisible = false;

--- a/classes/message_controller.php
+++ b/classes/message_controller.php
@@ -489,7 +489,7 @@ class message_controller {
         if (
             $this->messagebody === "0"
             // Make sure, we don't send anything, if booking option is hidden.
-            || $this->optionsettings->invisible == 1
+            || $this->optionsettings->invisible == MOD_BOOKING_OPTION_INVISIBLE
         ) {
             $this->msgcontrparam = MOD_BOOKING_MSGCONTRPARAM_DO_NOT_SEND;
         }

--- a/classes/option/fields/invisible.php
+++ b/classes/option/fields/invisible.php
@@ -170,7 +170,7 @@ class invisible extends field_base {
             $settings = singleton_service::get_instance_of_booking_option_settings($optionid);
             $timemadevisible = $settings->timemadevisible ?? 0;
             if (!empty($timemadevisible)) {
-                if ($settings->invisible == 0) {
+                if ($settings->invisible == MOD_BOOKING_OPTION_VISIBLE) {
                     $readabletimemadevisible = userdate($timemadevisible, get_string('strftimedaydatetime', 'langconfig'));
                     $mform->addElement(
                         'html',

--- a/classes/output/bookingoption_description.php
+++ b/classes/output/bookingoption_description.php
@@ -761,7 +761,7 @@ class bookingoption_description implements renderable, templatable {
      * @return bool true if invisible, else false
      */
     public function is_invisible(): bool {
-        if (isset($this->invisible) && $this->invisible == 1) {
+        if (isset($this->invisible) && $this->invisible == MOD_BOOKING_OPTION_INVISIBLE) {
             $ret = true;
         } else {
             $ret = false;

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -584,7 +584,7 @@ class shortcodes {
             // Only if the user has the right to see the link back, we show it.
             $settings = singleton_service::get_instance_of_booking_option_settings($option->id);
 
-            if ($option->invisible == 1) {
+            if ($option->invisible == MOD_BOOKING_OPTION_INVISIBLE) {
                 /** @var \context $context */
                 $context = context_module::instance($settings->cmid);
                 if (!has_capability('mod/booking:view', $context)) {

--- a/classes/table/bookingoptions_wbtable.php
+++ b/classes/table/bookingoptions_wbtable.php
@@ -297,13 +297,13 @@ class bookingoptions_wbtable extends wunderbyte_table {
             return '';
         }
         switch ($values->invisible) {
-            case '0':
+            case MOD_BOOKING_OPTION_VISIBLE:
                 $status = get_string('optionvisible', 'mod_booking');
                 break;
-            case '1':
+            case MOD_BOOKING_OPTION_INVISIBLE:
                 $status = get_string('optioninvisible', 'mod_booking');
                 break;
-            case '2':
+            case MOD_BOOKING_OPTION_VISIBLEWITHLINK:
                 $status = get_string('optionvisibledirectlink', 'mod_booking');
                 break;
         }

--- a/lib.php
+++ b/lib.php
@@ -396,6 +396,11 @@ define('MOD_BOOKING_RECURRING_OVERWRITE_CHILDREN', 2);
 define('MOD_BOOKING_RECURRING_APPLY_TO_SIBLINGS', 3);
 define('MOD_BOOKING_RECURRING_OVERWRITE_SIBLINGS', 4);
 
+// Define booking option visibility status.
+define('MOD_BOOKING_OPTION_VISIBLE', 0);
+define('MOD_BOOKING_OPTION_INVISIBLE', 1);
+define('MOD_BOOKING_OPTION_VISIBLEWITHLINK', 2);
+
 /**
  * Booking get coursemodule info.
  *


### PR DESCRIPTION
There is no logical change, only the constant is introduced. 
I checked because of the switch and it's fine, switches in php are not type-strict

I hope I found all occurrences of the visibility param for bookingoptions