### PR TITLE
Bugfix: Fix NULL useridfrom when booking manager account is missing (#1393)

### DIFF
--- a/classes/booking_settings.php
+++ b/classes/booking_settings.php
@@ -552,8 +552,8 @@ class booking_settings {
                 $this->bookingmanageruser = $dbrecord->bookingmanageruser;
             } else {
                 // Make sure, it's always null if booking manager could not be found.
-                $dbrecord->bookingmanageruser = (object)[];
-                $this->bookingmanageruser = (object)[];
+                $dbrecord->bookingmanageruser = null;
+                $this->bookingmanageruser = null;
             }
 
             return $dbrecord;

--- a/classes/message_controller.php
+++ b/classes/message_controller.php
@@ -410,11 +410,14 @@ class message_controller {
 
         $messagedata = new message();
 
-        // If a valid booking manager was set, use booking manager as sender, else global $USER will be set.
-        if (!empty($this->bookingmanager)) {
+        // If a valid booking manager was set, use booking manager as sender.
+        // Fall back to $USER if available (non-cron context), or noreply user (e.g. in adhoc task / cron).
+        if (!empty($this->bookingmanager->id)) {
             $messagedata->userfrom = $this->bookingmanager;
-        } else {
+        } else if (!empty($USER->id)) {
             $messagedata->userfrom = $USER;
+        } else {
+            $messagedata->userfrom = \core_user::get_noreply_user();
         }
         $messagedata->userto = $this->user;
         $messagedata->modulename = 'booking';
@@ -448,11 +451,14 @@ class message_controller {
 
         $messagedata = new stdClass();
 
-        // If a valid booking manager was set, use booking manager as sender, else global $USER will be set.
-        if (!empty($this->bookingmanager)) {
+        // If a valid booking manager was set, use booking manager as sender.
+        // Fall back to $USER if available (non-cron context), or noreply user (e.g. in adhoc task / cron).
+        if (!empty($this->bookingmanager->id)) {
             $messagedata->userfrom = $this->bookingmanager;
-        } else {
+        } else if (!empty($USER->id)) {
             $messagedata->userfrom = $USER;
+        } else {
+            $messagedata->userfrom = \core_user::get_noreply_user();
         }
 
         $messagedata->modulename = 'booking';


### PR DESCRIPTION
Fixes #1393

## What

Two-part fix for the `send_mail_by_rule_adhoc` task failure caused by a `NULL useridfrom` NOT NULL constraint violation.

## Changes

### `classes/booking_settings.php`

### `classes/message_controller.php`
In both `get_message_data_send_now()` and `get_message_data_queue_adhoc()`:
- Add `\core_user::get_noreply_user()` as final fallback for cron/adhoc-task context where `$USER->id === 0`

## Why the previous code broke

1. `load_bookingmanageruser_from_db()` returns `false`/`null` for a deleted manager
2. Fallback stored `(object)[]` — an empty stdClass — instead of `null`
4. Moodle derived `useridfrom = NULL` → PostgreSQL NOT NULL constraint violation
5. Adhoc task fails permanently with `faildelay = 86400`