### PR TITLE
issue #1430: remove dependency on tool_mocktesttime

### DIFF
--- a/backup/moodle2/restore_booking_stepslib.php
+++ b/backup/moodle2/restore_booking_stepslib.php
@@ -279,8 +279,8 @@ class restore_booking_activity_structure_step extends restore_activity_structure
         $oldcustomfields = $DB->get_records_sql($sql, $params);
         foreach ($oldcustomfields as $cf) {
             unset($cf->id);
-            $cf->timecreated = time();
-            $cf->timemodified = time();
+            $cf->timecreated  = \core\di::get(\core\clock::class)->time();
+            $cf->timemodified  = \core\di::get(\core\clock::class)->time();
             $cf->instanceid = $newitemid;
             $DB->insert_record('customfield_data', $cf);
         }
@@ -511,7 +511,7 @@ class restore_booking_activity_structure_step extends restore_activity_structure
                 throw new moodle_exception('entityrelationhasinvalidarea');
             }
             $data->instanceid = $this->get_mappingid('booking_option', $data->instanceid);
-            $data->timecreated = time();
+            $data->timecreated  = \core\di::get(\core\clock::class)->time();
             $DB->insert_record('local_entities_relations', $data);
             // No need to save this mapping as far as nothing depends on it.
         }
@@ -536,7 +536,7 @@ class restore_booking_activity_structure_step extends restore_activity_structure
                 throw new moodle_exception('entityrelationhasinvalidarea');
             }
             $data->instanceid = $this->get_mappingid('booking_optiondate', $data->instanceid);
-            $data->timecreated = time();
+            $data->timecreated  = \core\di::get(\core\clock::class)->time();
             $DB->insert_record('local_entities_relations', $data);
             // No need to save this mapping as far as nothing depends on it.
         }
@@ -554,8 +554,8 @@ class restore_booking_activity_structure_step extends restore_activity_structure
         if (get_config('booking', 'duplicationrestoresubbookings')) {
             $data = (object) $data;
             $data->optionid = $this->get_mappingid('booking_option', $data->optionid);
-            $data->timecreated = time();
-            $data->timemodified = time();
+            $data->timecreated  = \core\di::get(\core\clock::class)->time();
+            $data->timemodified  = \core\di::get(\core\clock::class)->time();
             $data->usermodified = $USER->id;
             $DB->insert_record('booking_subbooking_options', $data);
         }
@@ -616,8 +616,8 @@ class restore_booking_activity_structure_step extends restore_activity_structure
                 return;
             }
             $data->itemid = $this->get_mappingid('booking_option', $data->itemid);
-            $data->timecreated = time();
-            $data->timemodified = time();
+            $data->timecreated  = \core\di::get(\core\clock::class)->time();
+            $data->timemodified  = \core\di::get(\core\clock::class)->time();
             $DB->insert_record('local_shopping_cart_iteminfo', $data);
             // No need to save this mapping as far as nothing depends on it.
         }

--- a/classes/all_userbookings.php
+++ b/classes/all_userbookings.php
@@ -750,7 +750,7 @@ class all_userbookings extends \table_sql {
     public function col_certificate(stdClass $values) {
         $checkmark = '&#x2705; ';
         $cross = '&#x274C; ';
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         $certificates = $this->get_certificates_for_row($values);
         if (empty($certificates)) {

--- a/classes/bo_actions/action_types/userprofilefield.php
+++ b/classes/bo_actions/action_types/userprofilefield.php
@@ -105,7 +105,7 @@ class userprofilefield extends booking_action {
                     if (!empty($startstring)) {
                         $startdate = strtotime($startstring, time());
                     } else if (empty($startdate)) {
-                        $startdate = time();
+                        $startdate  = \core\di::get(\core\clock::class)->time();
                     }
 
                     $user->{$key} = userdate($startdate) . " - " . userdate($enddate);

--- a/classes/bo_availability/conditions/booking_time.php
+++ b/classes/bo_availability/conditions/booking_time.php
@@ -114,7 +114,7 @@ class booking_time implements bo_condition {
      */
     public function is_available(booking_option_settings $settings, int $userid, bool $not = false): bool {
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         // Here, the logic is easier when we set available to true first.
         $isavailable = true;

--- a/classes/bo_availability/conditions/cancelmyself.php
+++ b/classes/bo_availability/conditions/cancelmyself.php
@@ -111,7 +111,7 @@ class cancelmyself implements bo_condition {
     public function is_available(booking_option_settings $settings, int $userid, bool $not = false): bool {
 
         $optionid = $settings->id;
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         // This is the return value. Not available to begin with.
         $isavailable = false;
@@ -126,7 +126,7 @@ class cancelmyself implements bo_condition {
         }
 
         // Check if the option has its own canceluntil date and if it has already passed.
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $canceluntil = booking_option::get_value_of_json_by_key($optionid, 'canceluntil');
         if (!empty($canceluntil) && $now > $canceluntil) {
             return true;

--- a/classes/bo_availability/conditions/optionhasstarted.php
+++ b/classes/bo_availability/conditions/optionhasstarted.php
@@ -122,7 +122,7 @@ class optionhasstarted implements bo_condition {
         } else if (!empty($settings->coursestarttime)) {
             // In this case, we have to check if the booking option has already started.
             $start = $settings->coursestarttime;
-            $now = time();
+            $now  = \core\di::get(\core\clock::class)->time();
             $isavailable = $now > $start ? false : true;
         } else {
             $isavailable = true;

--- a/classes/booking_answers/booking_answers.php
+++ b/classes/booking_answers/booking_answers.php
@@ -809,7 +809,7 @@ class booking_answers {
 
         // If the config setting 'maxperuserdontcountpassed' is set, we don't count passed bookings.
         if (get_config('booking', 'maxperuserdontcountpassed')) {
-            $now = time();
+            $now  = \core\di::get(\core\clock::class)->time();
             foreach ($answers as $key => $answer) {
                 if (!empty($answer->courseendtime) && $answer->courseendtime < $now) {
                     unset($answers[$key]);

--- a/classes/booking_bookit.php
+++ b/classes/booking_bookit.php
@@ -303,21 +303,21 @@ class booking_bookit {
             } else if ($id === MOD_BOOKING_BO_COND_BOOKITBUTTON) {
                 $cache = cache::make('mod_booking', 'confirmbooking');
                 $cachekey = $userid . "_" . $settings->id . "_bookit";
-                $now = time();
+                $now = \core\di::get(\core\clock::class)->time();
                 $cache->set($userid, [$cachekey => $now]);
 
                 $isavailable = false;
             } else if ($id === MOD_BOOKING_BO_COND_BOOKWITHCREDITS) {
                 $cache = cache::make('mod_booking', 'confirmbooking');
                 $cachekey = $userid . "_" . $settings->id . "_bookwithcredits";
-                $now = time();
+                $now = \core\di::get(\core\clock::class)->time();
                 $cache->set($userid, [$cachekey => $now]);
 
                 $isavailable = false;
             } else if ($id === MOD_BOOKING_BO_COND_BOOKWITHSUBSCRIPTION) {
                 $cache = cache::make('mod_booking', 'confirmbooking');
                 $cachekey = $userid . "_" . $settings->id . "_bookwithsubscription";
-                $now = time();
+                $now = \core\di::get(\core\clock::class)->time();
                 $cache->set($userid, [$cachekey => $now]);
 
                 $isavailable = false;
@@ -364,7 +364,7 @@ class booking_bookit {
             } else if ($id === MOD_BOOKING_BO_COND_ASKFORCONFIRMATION) {
                 $cache = cache::make('mod_booking', 'confirmbooking');
                 $cachekey = $userid . "_" . $settings->id . "_confirmation";
-                $now = time();
+                $now = \core\di::get(\core\clock::class)->time();
                 $cache->set($userid, [$cachekey => $now]);
 
                 $isavailable = false;
@@ -386,7 +386,7 @@ class booking_bookit {
                      // If the cancel condition is blocking here, we can actually mark the option for cancelation.
                     $cache = cache::make('mod_booking', 'confirmbooking');
                     $cachekey = $userid . "_" . $settings->id . "_cancel";
-                    $now = time();
+                    $now = \core\di::get(\core\clock::class)->time();
                     $cache->set($userid, [$cachekey => $now]);
                 }
             } else if ($id === MOD_BOOKING_BO_COND_CONFIRMCANCEL) {

--- a/classes/booking_campaigns/campaigns_info.php
+++ b/classes/booking_campaigns/campaigns_info.php
@@ -535,7 +535,7 @@ class campaigns_info {
         string $operator
     ): bool {
         $isactive = false;
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         if ($starttime <= $now && $now <= $endtime) {
             if (!empty($fieldname)) {
                 if (is_string($fieldname) && $fieldname === $fieldvalue) {

--- a/classes/booking_option.php
+++ b/classes/booking_option.php
@@ -773,7 +773,7 @@ class booking_option {
                     !in_array($result->waitinglist, [MOD_BOOKING_STATUSPARAM_DELETED, MOD_BOOKING_STATUSPARAM_PREVIOUSLYBOOKED])
                 ) {
                     $result->waitinglist = MOD_BOOKING_STATUSPARAM_DELETED;
-                    $result->timemodified = time();
+                    $result->timemodified  = \core\di::get(\core\clock::class)->time();
                     $result->openruleexecution = $openruleexecution ? time() : 0;
                     // We mark all the booking answers as deleted.
                     $DB->update_record('booking_answers', $result);
@@ -1524,7 +1524,7 @@ class booking_option {
     ) {
 
         global $DB, $USER;
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         // For book with credits, we need to delete the cache.
         $settings = singleton_service::get_instance_of_booking_option_settings($optionid);
@@ -1565,7 +1565,7 @@ class booking_option {
             !empty($settings->selflearningcourse)
             && empty($currentanswerid) // We don't override on checkout.
         ) {
-            $now = time();
+            $now  = \core\di::get(\core\clock::class)->time();
             $duration = $settings->duration ?? 0;
             $end = empty($duration) ? 0 : $now + $duration;
             self::add_data_to_json($newanswer, 'selflearningendofsubscription', $end);
@@ -1601,18 +1601,18 @@ class booking_option {
             $tm = self::get_data_from_json($answer, 'confirmwaitinglist_timemodified');
             if (is_array($tm)) { // If it is an array, we just add new time to it.
                 $timemodified = $tm;
-                $timemodified[] = time();
+                $timemodified[]  = \core\di::get(\core\clock::class)->time();
             } else if (is_numeric($tm)) { // If it is a number we chnaged it to array of number and then we add new value.
                 $timemodified = [(int) $tm];
-                $timemodified[] = time();
+                $timemodified[]  = \core\di::get(\core\clock::class)->time();
             } else {
                 $timemodified = [];
-                $timemodified[] = time();
+                $timemodified[]  = \core\di::get(\core\clock::class)->time();
             }
         } else {
             $confirmationcount = 1;
             $modifieduserid[] = $USER->id;
-            $timemodified[] = time();
+            $timemodified[]  = \core\di::get(\core\clock::class)->time();
         }
 
         // The confirmation on the waitinglist is saved here.
@@ -1717,7 +1717,7 @@ class booking_option {
                 );
             } else {
                 // When it's the first reserveration, we just confirm it.
-                $currentanswer->timemodified = time();
+                $currentanswer->timemodified  = \core\di::get(\core\clock::class)->time();
                 $currentanswer->waitinglist = MOD_BOOKING_STATUSPARAM_BOOKED;
 
                 self::write_user_answer_to_db(
@@ -2039,7 +2039,7 @@ class booking_option {
                     // Timecreated is not a perfect solution, because users could have been on the waitinglist.
                     $now = $ba->timecreated;
                 } else {
-                    $now = time();
+                    $now  = \core\di::get(\core\clock::class)->time();
                 }
 
                 $duration = $this->settings->duration ?? 0;
@@ -3026,7 +3026,7 @@ class booking_option {
                 ['optionid' => $this->optionid, 'userid' => $userid, 'waitinglist' => MOD_BOOKING_STATUSPARAM_BOOKED]
             );
             $userdata->completed = '1';
-            $userdata->timemodified = time();
+            $userdata->timemodified  = \core\di::get(\core\clock::class)->time();
 
             $DB->update_record('booking_answers', $userdata);
 
@@ -3599,7 +3599,7 @@ class booking_option {
                 return false;
         }
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $openingtime = strtotime("+15 minutes", $now);
 
         if (!$sessionid) {
@@ -3725,7 +3725,7 @@ class booking_option {
 
         $settings = singleton_service::get_instance_of_booking_option_settings($optionid);
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         $record = $DB->get_record('booking_options', ['id' => $optionid]);
 
@@ -3782,7 +3782,7 @@ class booking_option {
     public static function get_consumed_quota(int $optionid) {
 
         $optionsettings = singleton_service::get_instance_of_booking_option_settings($optionid);
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $consumedquota = 0.0;
 
         if (empty($optionsettings->sessions)) {

--- a/classes/booking_rules/rules/rule_react_on_event.php
+++ b/classes/booking_rules/rules/rule_react_on_event.php
@@ -425,7 +425,7 @@ class rule_react_on_event implements booking_rule {
 
         foreach ($records as $record) {
             // Set the time of when the task should run.
-            $nextruntime = time();
+            $nextruntime  = \core\di::get(\core\clock::class)->time();
             $record->rulename = $this->rulename;
             $record->nextruntime = $nextruntime;
             $action->execute($record);
@@ -511,7 +511,7 @@ class rule_react_on_event implements booking_rule {
             return true;
         }
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $days = (int)$aftercompletiondays;
         $add = $days * 24 * 60 * 60;
         if ($endtime + $add <= $now) {

--- a/classes/dates.php
+++ b/classes/dates.php
@@ -173,7 +173,7 @@ class dates {
         /* $element->setValue($datescounter); */ // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
         $elements[] = $element;
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $nextfullhour = strtotime(date('Y-m-d H:00:00', $now)) + 3600;
 
         // If we want to show more dates than we currently have...

--- a/classes/elective.php
+++ b/classes/elective.php
@@ -503,7 +503,7 @@ class elective {
         global $DB;
         // Get all booking options with associated Moodle courses that have enrolmentstatus 0 and coursestartdate in the past.
         $select = "enrolmentstatus < 1 AND coursestarttime < :now";
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $boids = $DB->get_records_select_menu('booking_options', $select, ['now' => $now], '', 'id, bookingid');
         foreach ($boids as $optionid => $bookingid) {
             // Might happen for templates.

--- a/classes/enrollink.php
+++ b/classes/enrollink.php
@@ -432,7 +432,7 @@ class enrollink {
         $data->courseid = $settings->courseid;
         $data->userid = $USER->id;
         $data->usermodified = $USER->id;
-        $data->timecreated = time();
+        $data->timecreated  = \core\di::get(\core\clock::class)->time();
         $data->timemodified = $data->timecreated;
         $data->places = (string) $places;
         $data->erlid = md5(random_string());

--- a/classes/form/editteachersforoptiondate_form.php
+++ b/classes/form/editteachersforoptiondate_form.php
@@ -182,7 +182,7 @@ class editteachersforoptiondate_form extends \core_form\dynamic_form {
             }
         }
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         // Save deductions if there are any.
         $settings = singleton_service::get_instance_of_booking_option_settings($data->optionid);

--- a/classes/ical.php
+++ b/classes/ical.php
@@ -219,7 +219,7 @@ class ical {
         if (($coursedates || $sessiontimes)) {
             $this->datesareset = true;
             $this->user = $DB->get_record('user', ['id' => $user->id]);
-            $now = time();
+            $now  = \core\di::get(\core\clock::class)->time();
             $this->dtstamp = $this->generate_timestamp($now);
             $this->summary = $this->escape($settings->get_title_with_prefix());
             $this->description = $this->escape($settings->description ?? '', true);

--- a/classes/local/certificate_conditions/certificate_conditions.php
+++ b/classes/local/certificate_conditions/certificate_conditions.php
@@ -213,7 +213,7 @@ class certificate_conditions {
                 $record->actionjson = $data->actionjson ?? null;
             }
         }
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         if (!empty($data->id) && $data->id > 0) {
             $record->id = $data->id;
             $record->timemodified = $now;

--- a/classes/local/checkanswers/checkanswers.php
+++ b/classes/local/checkanswers/checkanswers.php
@@ -127,7 +127,7 @@ class checkanswers {
             // For security, we schedule the taks five minutes in the future.
             // This will give the possiblity to cancel the task if needed.
             if (PHPUNIT_TEST) {
-                $executiontime = time(); // Now.
+                $executiontime  = \core\di::get(\core\clock::class)->time(); // Now.
             } else {
                 $executiontime = strtotime('+ 15 minutes', time());
             }

--- a/classes/option/fields/competencies.php
+++ b/classes/option/fields/competencies.php
@@ -393,8 +393,8 @@ class competencies extends field_base {
                 ]))->out(false);
             $record->contextid = $cmid;
             $record->status = 1; // 1 = active
-            $record->timecreated = time();
-            $record->timemodified = time();
+            $record->timecreated  = \core\di::get(\core\clock::class)->time();
+            $record->timemodified  = \core\di::get(\core\clock::class)->time();
 
             $userevidence = new user_evidence(0, $record);
             $userevidence->create();

--- a/classes/option/fields/invisible.php
+++ b/classes/option/fields/invisible.php
@@ -104,7 +104,7 @@ class invisible extends field_base {
         $optionid = $formdata->optionid ?? $formdata->id ?? 0;
         if (empty($optionid)) {
             // The option is new.
-            $newoption->timemadevisible = time();
+            $newoption->timemadevisible  = \core\di::get(\core\clock::class)->time();
         } else if (
             isset($change['fieldname'])
             && isset($change['oldvalue'])
@@ -114,7 +114,7 @@ class invisible extends field_base {
             && $change['newvalue'] == 0 // Was set to visible.
         ) {
             // The option was set from invisible to visible.
-            $newoption->timemadevisible = time();
+            $newoption->timemadevisible  = \core\di::get(\core\clock::class)->time();
         } else {
             // In all other cases, we use the timecreated value.
             $settings = singleton_service::get_instance_of_booking_option_settings($optionid);

--- a/classes/option/fields/timecreated.php
+++ b/classes/option/fields/timecreated.php
@@ -98,7 +98,7 @@ class timecreated extends field_base {
         $optionid = $formdata->optionid ?? $formdata->id ?? 0;
         if (empty($optionid)) {
             // The option is new.
-            $newoption->timecreated = time();
+            $newoption->timecreated  = \core\di::get(\core\clock::class)->time();
         } else {
             // It's an existing option.
             $settings = singleton_service::get_instance_of_booking_option_settings($optionid);
@@ -106,7 +106,7 @@ class timecreated extends field_base {
                 if (!empty($settings->timemodified)) {
                     $newoption->timecreated = $settings->timemodified;
                 } else {
-                    $newoption->timecreated = time();
+                    $newoption->timecreated  = \core\di::get(\core\clock::class)->time();
                 }
             } else {
                 $newoption->timecreated = $settings->timecreated;

--- a/classes/option/fields/timemodified.php
+++ b/classes/option/fields/timemodified.php
@@ -95,7 +95,7 @@ class timemodified extends field_base {
     ): array {
         parent::prepare_save_field($formdata, $newoption, $updateparam, 0);
         // We always store the current time in the time modified field, no matter what.
-        $newoption->timemodified = time();
+        $newoption->timemodified  = \core\di::get(\core\clock::class)->time();
 
         return [];
     }

--- a/classes/output/elective_modal.php
+++ b/classes/output/elective_modal.php
@@ -78,7 +78,7 @@ class elective_modal implements renderable, templatable {
 
         $cmid = (int)$booking->cmid;
         $cachearray = $cache->get($cmid);
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         // If the the cache has not yet expired, we use it.
         if (isset($cachearray['expirationtime']) && $cachearray['expirationtime'] > $now) {

--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -328,7 +328,7 @@ class mobile {
         $data['whichview'] = $whichview;
         $data['cmid'] = $cmid;
         $data['mybookings'] = $outputdata;
-        $data['timestamp'] = time();
+        $data['timestamp']  = \core\di::get(\core\clock::class)->time();
         $data['mybookings'][0]['itemid'] = null;
         return [
             'templates' => [

--- a/classes/output/prepagemodal.php
+++ b/classes/output/prepagemodal.php
@@ -126,7 +126,7 @@ class prepagemodal implements renderable, templatable {
      */
     public function export_for_template(renderer_base $output) {
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $rand = rand(1, 1000);
 
         return [

--- a/classes/shopping_cart/service_provider.php
+++ b/classes/shopping_cart/service_provider.php
@@ -414,7 +414,7 @@ class service_provider implements \local_shopping_cart\local\callback\service_pr
             by setting a canceluntil date in shopping_cart_history table directly. */
             // Check if the option has its own canceluntil date and if it has already passed.
             // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-            /* $now = time();
+            /* $now  = \core\di::get(\core\clock::class)->time();
             $canceluntil = booking_option::get_value_of_json_by_key($itemid, 'canceluntil');
             if (!empty($canceluntil) && $now > $canceluntil) {
                 $allowedtocancel = false;

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -1035,7 +1035,7 @@ class shortcodes {
                     $table
                 );
         if (!empty($args['futureonly'])) {
-            $startoftoday = time();
+            $startoftoday  = \core\di::get(\core\clock::class)->time();
             $where .= " AND courseendtime > $startoftoday ";
         }
         $table->set_filter_sql($fields, $from, $where, $filter, $params);

--- a/classes/subbookings.php
+++ b/classes/subbookings.php
@@ -77,7 +77,7 @@ class subbookings {
 
         global $DB, $USER;
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         $status = $addedtocart ? MOD_BOOKING_STATUSPARAM_BOOKED : MOD_BOOKING_STATUSPARAM_RESERVED;
 

--- a/classes/subbookings/sb_types/subbooking_additionalitem.php
+++ b/classes/subbookings/sb_types/subbooking_additionalitem.php
@@ -192,7 +192,7 @@ class subbooking_additionalitem implements booking_subbooking {
         global $DB, $USER;
 
         $record = new stdClass();
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         if (!isset($data->json)) {
             $jsonobject = new stdClass();

--- a/classes/subbookings/sb_types/subbooking_additionalperson.php
+++ b/classes/subbookings/sb_types/subbooking_additionalperson.php
@@ -160,7 +160,7 @@ class subbooking_additionalperson implements booking_subbooking {
         global $DB, $USER;
 
         $record = new stdClass();
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         if (!isset($data->json)) {
             $jsonobject = new stdClass();

--- a/classes/subbookings/sb_types/subbooking_timeslot.php
+++ b/classes/subbookings/sb_types/subbooking_timeslot.php
@@ -147,7 +147,7 @@ class subbooking_timeslot implements booking_subbooking {
         global $DB, $USER;
 
         $record = new stdClass();
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         if (!isset($data->json)) {
             $jsonobject = new stdClass();

--- a/classes/subbookings/subbookings_info.php
+++ b/classes/subbookings/subbookings_info.php
@@ -501,7 +501,7 @@ class subbookings_info {
 
         global $DB, $USER;
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
 
         $id = 0;
 

--- a/classes/task/enrol_bookedusers_tocourse.php
+++ b/classes/task/enrol_bookedusers_tocourse.php
@@ -59,7 +59,7 @@ class enrol_bookedusers_tocourse extends \core\task\scheduled_task {
 
         // Get all booking options with associated Moodle courses that have enrolmentstatus 0 and coursestartdate in the past.
         $select = "enrolmentstatus < 1 AND (coursestarttime < :now OR coursestarttime IS NULL)";
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $boids = $DB->get_records_select_menu('booking_options', $select, ['now' => $now], '', 'id, bookingid');
 
         foreach ($boids as $optionid => $bookingid) {

--- a/classes/task/remove_activity_completion.php
+++ b/classes/task/remove_activity_completion.php
@@ -50,7 +50,7 @@ class remove_activity_completion extends \core\task\scheduled_task {
      */
     public function execute() {
         global $DB, $CFG;
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $params = ['now' => $now];
 
         $result = $DB->get_records_sql(
@@ -77,7 +77,7 @@ class remove_activity_completion extends \core\task\scheduled_task {
             $booking = $DB->get_record('booking', ['id' => $value->bookingid]);
 
             $userdata->completed = '0';
-            $userdata->timemodified = time();
+            $userdata->timemodified  = \core\di::get(\core\clock::class)->time();
 
             $DB->update_record('booking_answers', $userdata);
 

--- a/classes/task/send_notification_mails.php
+++ b/classes/task/send_notification_mails.php
@@ -82,7 +82,7 @@ class send_notification_mails extends \core\task\scheduled_task {
             $booking = singleton_service::get_instance_of_booking_by_bookingid($bookingid);
             $settings = singleton_service::get_instance_of_booking_option_settings($optionid);
 
-            $now = time();
+            $now  = \core\di::get(\core\clock::class)->time();
             if (
                 (!empty($settings->courseendtime) && $now > $settings->courseendtime)
                 || (empty($booking->id) || empty($settings->id))

--- a/classes/task/send_reminder_mails.php
+++ b/classes/task/send_reminder_mails.php
@@ -73,7 +73,7 @@ class send_reminder_mails extends \core\task\scheduled_task {
             return;
         }
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $toprocess = $DB->get_records_sql(
             'SELECT bo.id optionid, bo.bookingid, bo.coursestarttime, b.daystonotify, b.daystonotify2, bo.sent, bo.sent2
             FROM {booking_options} bo
@@ -138,7 +138,7 @@ class send_reminder_mails extends \core\task\scheduled_task {
     private function send_session_notifications() {
         global $DB;
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $sessionstoprocess = $DB->get_records_sql(
             "SELECT bod.id optiondateid, bod.bookingid, bod.optionid, bod.coursestarttime, bod.daystonotify, bod.sent
             FROM {booking_optiondates} bod
@@ -169,7 +169,7 @@ class send_reminder_mails extends \core\task\scheduled_task {
     private function send_teacher_notifications() {
         global $DB;
 
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $toprocess = $DB->get_records_sql(
             "SELECT bo.id optionid, bo.bookingid, bo.coursestarttime, b.daystonotifyteachers, bo.sentteachers
             FROM {booking_options} bo
@@ -221,7 +221,7 @@ class send_reminder_mails extends \core\task\scheduled_task {
      */
     private function send_notification(int $messageparam, stdClass $record, int $daystonotify) {
         global $DB;
-        $now = time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $timetosend = strtotime('-' . $daystonotify . ' days', $record->coursestarttime);
         if ($timetosend < $now) {
             $optionid = $record->optionid;

--- a/importexcel.php
+++ b/importexcel.php
@@ -112,7 +112,7 @@ if ($mform->is_cancelled()) {
 
                 if ($user !== false) {
                     $user->completed = $line[$completedpos];
-                    $user->timemodified = time();
+                    $user->timemodified  = \core\di::get(\core\clock::class)->time();
                     $DB->update_record('booking_answers', $user, false);
 
                     $countcompleted = $DB->count_records(

--- a/lib.php
+++ b/lib.php
@@ -694,7 +694,7 @@ function booking_comment_validate(stdClass $commentparam): bool {
 function booking_add_instance($booking) {
     global $DB, $CFG;
 
-    $booking->timemodified = time();
+    $booking->timemodified  = \core\di::get(\core\clock::class)->time();
 
     if (isset($booking->responsesfields) && is_array($booking->responsesfields) && count($booking->responsesfields) > 0) {
         $booking->responsesfields = implode(',', $booking->responsesfields);
@@ -927,7 +927,7 @@ function booking_add_instance($booking) {
                 if (isset($booking->limit[$key])) {
                     $option->maxanswers = $booking->limit[$key];
                 }
-                $option->timemodified = time();
+                $option->timemodified  = \core\di::get(\core\clock::class)->time();
                 $DB->insert_record("booking_options", $option);
             }
         }
@@ -954,7 +954,7 @@ function booking_update_instance($booking) {
     $bookingid = $booking->id;
     $bookingsettings = singleton_service::get_instance_of_booking_settings_by_bookingid($bookingid);
 
-    $booking->timemodified = time();
+    $booking->timemodified  = \core\di::get(\core\clock::class)->time();
     $cm = get_coursemodule_from_instance('booking', $booking->id);
     $context = context_module::instance($cm->id);
 
@@ -1229,7 +1229,7 @@ function booking_update_instance($booking) {
             if (isset($booking->limit[$key])) {
                 $option->maxanswers = $booking->limit[$key];
             }
-            $option->timemodified = time();
+            $option->timemodified  = \core\di::get(\core\clock::class)->time();
             if (isset($booking->optionid[$key]) && !empty($booking->optionid[$key])) { // Existing booking record.
                 $option->id = $booking->optionid[$key];
                 if (!empty($value)) {

--- a/report.php
+++ b/report.php
@@ -87,7 +87,7 @@ if ($optionid > 0) {
     $sqlvalues['optionid'] = $optionid;
 }
 
-$timestamp = time();
+$timestamp  = \core\di::get(\core\clock::class)->time();
 
 $urlparams['searchdateday'] = "";
 if ($searchdateday > 0) {

--- a/settings.php
+++ b/settings.php
@@ -218,7 +218,7 @@ if ($ADMIN->fulltree) {
         $expirationdate = wb_payment::decryptlicensekey($licensekey);
         if (!empty($expirationdate)) {
             $expirationdatetimestamp = strtotime($expirationdate);
-            $now = time();
+            $now  = \core\di::get(\core\clock::class)->time();
             if ($expirationdatetimestamp < $now) {
                 // License has expired.
                 $licensekeydesc = "<p style='color: red; font-weight: bold'>"

--- a/tests/backup/backup_restore_test.php
+++ b/tests/backup/backup_restore_test.php
@@ -23,7 +23,6 @@ use backup;
 use stdClass;
 use context_system;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -52,8 +51,7 @@ final class backup_restore_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_actions/booking_action_bookotheroption_test.php
+++ b/tests/bo_actions/booking_action_bookotheroption_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use mod_booking\table\manageusers_table;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class booking_action_bookotheroption_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_actions/booking_action_test.php
+++ b/tests/bo_actions/booking_action_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use mod_booking\table\manageusers_table;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class booking_action_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_all_test.php
+++ b/tests/bo_availability/condition_all_test.php
@@ -36,7 +36,6 @@ use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -58,8 +57,7 @@ final class condition_all_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_allowupdate_test.php
+++ b/tests/bo_availability/condition_allowupdate_test.php
@@ -32,7 +32,6 @@ use mod_booking_generator;
 use context_system;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 use mod_booking\booking_rules\booking_rules;
 use mod_booking\booking_rules\rules_info;
 
@@ -55,8 +54,7 @@ final class condition_allowupdate_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_allowupdatetimestamp_test.php
+++ b/tests/bo_availability/condition_allowupdatetimestamp_test.php
@@ -32,7 +32,6 @@ use mod_booking_generator;
 use context_system;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -53,8 +52,7 @@ final class condition_allowupdatetimestamp_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_bookingpolicy_test.php
+++ b/tests/bo_availability/condition_bookingpolicy_test.php
@@ -39,7 +39,6 @@ use moodle_url;
 use mod_booking\booking_rules\booking_rules;
 use mod_booking\booking_rules\rules_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -62,8 +61,7 @@ final class condition_bookingpolicy_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_bookingtime_test.php
+++ b/tests/bo_availability/condition_bookingtime_test.php
@@ -37,7 +37,6 @@ use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
 use moodle_page;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -59,8 +58,7 @@ final class condition_bookingtime_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_enrolledincohorts_test.php
+++ b/tests/bo_availability/condition_enrolledincohorts_test.php
@@ -31,7 +31,6 @@ use context_module;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -53,8 +52,7 @@ final class condition_enrolledincohorts_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
         $this->preventResetByRollback();
     }

--- a/tests/bo_availability/condition_enrolledincourse_test.php
+++ b/tests/bo_availability/condition_enrolledincourse_test.php
@@ -31,7 +31,6 @@ use context_module;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -53,8 +52,7 @@ final class condition_enrolledincourse_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_hascompetency_test.php
+++ b/tests/bo_availability/condition_hascompetency_test.php
@@ -34,7 +34,6 @@ use core_competency\user_competency;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for hascompetency availability condition.
@@ -51,8 +50,7 @@ final class condition_hascompetency_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_maxoptionsfromcategory_test.php
+++ b/tests/bo_availability/condition_maxoptionsfromcategory_test.php
@@ -35,7 +35,6 @@ use mod_booking\price;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -57,8 +56,7 @@ final class condition_maxoptionsfromcategory_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_otheroptionsavailable_test.php
+++ b/tests/bo_availability/condition_otheroptionsavailable_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use mod_booking\table\manageusers_table;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class condition_otheroptionsavailable_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_previouslybooked_completion_test.php
+++ b/tests/bo_availability/condition_previouslybooked_completion_test.php
@@ -29,7 +29,6 @@ use advanced_testcase;
 use mod_booking_generator;
 use mod_booking\singleton_service;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
@@ -43,8 +42,7 @@ final class condition_previouslybooked_completion_test extends advanced_testcase
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_skipableconditions_test.php
+++ b/tests/bo_availability/condition_skipableconditions_test.php
@@ -32,7 +32,6 @@ use context_module;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class condition_skipableconditions_test extends advanced_testcase {
         parent::setUp();
         $this->resetAfterTest();
         $this->preventResetByRollback();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bo_availability/condition_userprofilefield_test.php
+++ b/tests/bo_availability/condition_userprofilefield_test.php
@@ -31,7 +31,6 @@ use context_module;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -53,8 +52,7 @@ final class condition_userprofilefield_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_answers/booking_answers_test.php
+++ b/tests/booking_answers/booking_answers_test.php
@@ -20,7 +20,6 @@ use advanced_testcase;
 use mod_booking\singleton_service;
 use mod_booking\booking_bookit;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 use stdClass;
 use mod_booking_generator;
 
@@ -42,8 +41,7 @@ final class booking_answers_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 
@@ -69,8 +67,7 @@ final class booking_answers_test extends advanced_testcase {
         set_config('timezone', 'Europe/Kyiv');
         set_config('forcetimezone', 'Europe/Kyiv');
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         // Setup test data.
 
@@ -218,12 +215,11 @@ final class booking_answers_test extends advanced_testcase {
         // Check multiple bookings if the opton is enabled.
         if (!empty($optionsettings['multiplebookings'])) {
             // We advance the time and check bo_availabilty to see if expectation are met.
-            $time = time_mock::get_mock_time();
-            $this->assertSame(time(), $time);
+            $time = \core\di::get(\core\clock::class)->time();
             $clockforwardshift = $time + $optionsettings['allowtobookagainafter'] + 20;
-            time_mock::set_mock_time($time + $clockforwardshift); // Jump N seconds into the future.
-            $future = time_mock::get_mock_time();
-            $this->assertEquals(time(), $future);
+            \core\di::get(\core\clock::class)->set_to($time + $clockforwardshift); // Jump N seconds into the future.
+            $future = \core\di::get(\core\clock::class)->time();
+            $this->assertEquals($time + $clockforwardshift, $future);
 
             // Book again option for students 2 and 3.
             $this->setUser($student2);
@@ -235,12 +231,11 @@ final class booking_answers_test extends advanced_testcase {
             $a = $DB->get_records('booking_answers', ['waitinglist' => 6]);
 
             // We advance the time and check bo_availabilty to see if expectation are met.
-            $time = time_mock::get_mock_time();
-            $this->assertSame(time(), $time);
+            $time = \core\di::get(\core\clock::class)->time();
             $clockforwardshift = $time + $optionsettings['allowtobookagainafter'] + 30;
-            time_mock::set_mock_time($time + $clockforwardshift); // Jump N seconds into the future.
-            $future = time_mock::get_mock_time();
-            $this->assertEquals(time(), $future);
+            \core\di::get(\core\clock::class)->set_to($time + $clockforwardshift); // Jump N seconds into the future.
+            $future = \core\di::get(\core\clock::class)->time();
+            $this->assertEquals($time + $clockforwardshift, $future);
 
             // Book again option for students 2 and 3.
             $this->setUser($student2);

--- a/tests/booking_answers/booking_answers_timecompleted_test.php
+++ b/tests/booking_answers/booking_answers_timecompleted_test.php
@@ -20,7 +20,6 @@ use advanced_testcase;
 use mod_booking\singleton_service;
 use mod_booking\booking_bookit;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 use stdClass;
 use mod_booking_generator;
 
@@ -40,8 +39,7 @@ final class booking_answers_timecompleted_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 
@@ -67,8 +65,7 @@ final class booking_answers_timecompleted_test extends advanced_testcase {
         set_config('timezone', 'Europe/Kyiv');
         set_config('forcetimezone', 'Europe/Kyiv');
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         // Setup test data.
 

--- a/tests/booking_campaigns/booking_campaigns_test.php
+++ b/tests/booking_campaigns/booking_campaigns_test.php
@@ -33,7 +33,6 @@ use context_system;
 use mod_booking\bo_availability\bo_info;
 use mod_booking\booking_campaigns\campaigns_info;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class booking_campaigns_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_campaigns/campaign_freetobookagain_test.php
+++ b/tests/booking_campaigns/campaign_freetobookagain_test.php
@@ -31,7 +31,6 @@ use context_system;
 use mod_booking\bo_availability\bo_info;
 use mod_booking\task\purge_campaign_caches;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -52,8 +51,7 @@ final class campaign_freetobookagain_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 
@@ -189,7 +187,7 @@ final class campaign_freetobookagain_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ALREADYBOOKED, $id);
 
         // Book student2 via waitinglist then confirm (verified).
-        time_mock::set_mock_time(strtotime('+1 hour', time()));
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 hour', time()));
         $this->setUser($student2);
         singleton_service::destroy_user($student2->id);
         $result = booking_bookit::bookit('option', $settings->id, $student2->id);
@@ -200,7 +198,7 @@ final class campaign_freetobookagain_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ALREADYBOOKED, $id);
 
         // Now the option is fully booked (2/2). Put student3 on the waitinglist.
-        time_mock::set_mock_time(strtotime('+2 hours', time()));
+        \core\di::get(\core\clock::class)->set_to(strtotime('+2 hours', time()));
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings->id, $student3->id);

--- a/tests/booking_cohort_subscription_test.php
+++ b/tests/booking_cohort_subscription_test.php
@@ -29,7 +29,6 @@ use advanced_testcase;
 use context_module;
 use context_system;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -47,8 +46,7 @@ final class booking_cohort_subscription_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_course_connection_test.php
+++ b/tests/booking_course_connection_test.php
@@ -33,7 +33,6 @@ use mod_booking\local\connectedcourse;
 use context_system;
 use core_course_category;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Class handling tests for booking options.
@@ -50,8 +49,7 @@ final class booking_course_connection_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_groupenrolment_test.php
+++ b/tests/booking_groupenrolment_test.php
@@ -30,7 +30,6 @@ use advanced_testcase;
 use coding_exception;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -53,8 +52,7 @@ final class booking_groupenrolment_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_option_group_creation_test.php
+++ b/tests/booking_option_group_creation_test.php
@@ -38,7 +38,6 @@ use advanced_testcase;
 use cache_helper;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests that a group is automatically created when a booking option with a
@@ -57,8 +56,7 @@ final class booking_option_group_creation_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_option_test.php
+++ b/tests/booking_option_test.php
@@ -36,7 +36,6 @@ use context_system;
 use context_module;
 use core_course_category;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Class handling tests for booking options.
@@ -53,8 +52,7 @@ final class booking_option_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_options_customfields/booking_customfields_on_optionview_test.php
+++ b/tests/booking_options_customfields/booking_customfields_on_optionview_test.php
@@ -20,7 +20,6 @@ use advanced_testcase;
 use context_system;
 use mod_booking_generator;
 use mod_booking\output\bookingoption_description;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for configured customfields shown on option view.
@@ -37,8 +36,7 @@ final class booking_customfields_on_optionview_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_options_customfields/booking_customfields_rules_test.php
+++ b/tests/booking_options_customfields/booking_customfields_rules_test.php
@@ -30,7 +30,6 @@ use advanced_testcase;
 use coding_exception;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for booking option field class teachers.
@@ -48,8 +47,7 @@ final class booking_customfields_rules_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_options_fields/date_series_in_semester_test.php
+++ b/tests/booking_options_fields/date_series_in_semester_test.php
@@ -33,7 +33,6 @@ use mod_booking\booking_rules\rules_info;
 use mod_booking\option\fields_info;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -56,8 +55,7 @@ final class date_series_in_semester_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_options_fields/moveoption_test.php
+++ b/tests/booking_options_fields/moveoption_test.php
@@ -37,7 +37,6 @@ use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -60,8 +59,7 @@ final class moveoption_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_options_fields/recurringoptions_test.php
+++ b/tests/booking_options_fields/recurringoptions_test.php
@@ -37,7 +37,6 @@ use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -60,8 +59,7 @@ final class recurringoptions_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_options_fields/sharedplaces_test.php
+++ b/tests/booking_options_fields/sharedplaces_test.php
@@ -32,7 +32,6 @@ use mod_booking\bo_availability\bo_info;
 use mod_booking\option\fields_info;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -55,8 +54,7 @@ final class sharedplaces_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_options_fields/teachers_calendar_test.php
+++ b/tests/booking_options_fields/teachers_calendar_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use mod_booking\option\fields_info;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class teachers_calendar_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_rules/rule_cancellation_test.php
+++ b/tests/booking_rules/rule_cancellation_test.php
@@ -26,7 +26,6 @@
 namespace mod_booking;
 
 use advanced_testcase;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 
 /**
@@ -50,8 +49,7 @@ final class rule_cancellation_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
     }
 
     /**
@@ -94,8 +92,7 @@ final class rule_cancellation_test extends advanced_testcase {
         $this->setAdminUser();
         $bdata = self::booking_common_settings_provider();
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         if (isset($data['config'])) {
             foreach ($data['config'] as $key => $value) {
@@ -182,7 +179,7 @@ final class rule_cancellation_test extends advanced_testcase {
             // Get actual messages.
             ob_start();
             $messagesink = $this->redirectMessages();
-            $plugingenerator->runtaskswithintime(time_mock::get_mock_time());
+            $plugingenerator->runtaskswithintime(\core\di::get(\core\clock::class)->time());
             $messages = $messagesink->get_messages();
             $trace = ob_get_clean();
             $messagesink->close();

--- a/tests/booking_rules/rule_specifictime_test.php
+++ b/tests/booking_rules/rule_specifictime_test.php
@@ -28,7 +28,6 @@ namespace mod_booking;
 use advanced_testcase;
 use local_entities_generator;
 use mod_booking\booking_rules\rules_info;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 
 /**
@@ -52,8 +51,7 @@ final class rule_specifictime_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
     }
 
     /**
@@ -93,8 +91,7 @@ final class rule_specifictime_test extends advanced_testcase {
         $this->setAdminUser();
         $bdata = self::booking_common_settings_provider();
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         // Setup course, users, booking instance.
         $courses = [];
@@ -166,17 +163,17 @@ final class rule_specifictime_test extends advanced_testcase {
         $this->assertCount($expected['initialnumberoftasks'], $tasks, 'wrong number of tasks');
 
         if (isset($expected['tasksperoptiondates'])) {
-            $time = time_mock::get_mock_time();
+            $time = \core\di::get(\core\clock::class)->time();
             unset_config('noemailever');
             foreach ($expected['tasksperoptiondates'] as $tasksperoptiondates) {
                 if (!empty($data['mock_timestamp'])) {
-                    time_mock::set_mock_time($tasksperoptiondates['mock_time']);
+                    \core\di::get(\core\clock::class)->set_to($tasksperoptiondates['mock_time']);
                 } else {
-                    time_mock::set_mock_time(strtotime($tasksperoptiondates['mock_time'], $time));
+                    \core\di::get(\core\clock::class)->set_to(strtotime($tasksperoptiondates['mock_time'], $time));
                 }
                 ob_start();
                 $messagesink = $this->redirectMessages();
-                $plugingenerator->runtaskswithintime(time_mock::get_mock_time());
+                $plugingenerator->runtaskswithintime(\core\di::get(\core\clock::class)->time());
                 $messages = $messagesink->get_messages();
                 $trace = ob_get_clean();
                 $messagesink->close();

--- a/tests/booking_rules/rules_enrollink_test.php
+++ b/tests/booking_rules/rules_enrollink_test.php
@@ -36,7 +36,6 @@ use mod_booking\local\mobile\customformstore;
 use local_shopping_cart\shopping_cart;
 use local_shopping_cart\local\cartstore;
 use mod_booking\enrollink;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for booking enrollink rules.
@@ -55,8 +54,7 @@ final class rules_enrollink_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_rules/rules_n_days_test.php
+++ b/tests/booking_rules/rules_n_days_test.php
@@ -29,7 +29,6 @@ use advanced_testcase;
 use local_entities_generator;
 use stdClass;
 use mod_booking\booking_rules\rules_info;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 
 /**
@@ -137,7 +136,7 @@ final class rules_n_days_test extends advanced_testcase {
         $this->assertTrue($newtaskfound, 'New task should be created');
 
         // Advance time to the old task time and run tasks.
-        time_mock::set_mock_time(strtotime('+7 days', time()));
+        \core\di::get(\core\clock::class)->set_to(strtotime('+7 days', time()));
         unset_config('noemailever');
         ob_start();
         $messagesink = $this->redirectMessages();
@@ -162,8 +161,7 @@ final class rules_n_days_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         $this->preventResetByRollback();
     }
 
@@ -437,9 +435,9 @@ final class rules_n_days_test extends advanced_testcase {
             booking_option::cancelbookingoption($option1->id);
         }
 
-        $time = time_mock::get_mock_time();
-        time_mock::set_mock_time(strtotime('+5 days', $time));
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+5 days', $time));
+        $time = \core\di::get(\core\clock::class)->time();
 
         ob_start();
         $this->runAdhocTasks();
@@ -538,9 +536,9 @@ final class rules_n_days_test extends advanced_testcase {
             booking_option::cancelbookingoption($option1->id);
         }
 
-        $time = time_mock::get_mock_time();
-        time_mock::set_mock_time(strtotime('+15 days', $time));
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+15 days', $time));
+        $time = \core\di::get(\core\clock::class)->time();
 
         $messagesink = $this->redirectMessages();
 
@@ -554,12 +552,12 @@ final class rules_n_days_test extends advanced_testcase {
         $this->assertCount($data['canceloption'] ? 0 : 1, $messages);
 
         ob_start();
-        $plugingenerator->runtaskswithintime(time_mock::get_mock_time());
+        $plugingenerator->runtaskswithintime(\core\di::get(\core\clock::class)->time());
         $res = ob_get_clean(); // Not used here, but needed to clear buffer.
 
-        $time = time_mock::get_mock_time();
-        time_mock::set_mock_time(strtotime('+15 days', $time));
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+15 days', $time));
+        $time = \core\di::get(\core\clock::class)->time();
 
         ob_start();
         $plugingenerator->runtaskswithintime($time);
@@ -596,8 +594,7 @@ final class rules_n_days_test extends advanced_testcase {
         $this->setAdminUser();
         $bdata = self::booking_common_settings_provider();
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         // Setup course, users, booking instance.
         $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
@@ -713,13 +710,13 @@ final class rules_n_days_test extends advanced_testcase {
         $tasks = \core\task\manager::get_adhoc_tasks('\mod_booking\task\send_mail_by_rule_adhoc');
         $this->assertCount($expected['numberoftasks'], $tasks, 'wrong number of tasks');
 
-        $time = time_mock::get_mock_time();
-        time_mock::set_mock_time(strtotime('30 June 2050 16:00', $time));
+        $time = \core\di::get(\core\clock::class)->time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('30 June 2050 16:00', $time));
 
         unset_config('noemailever');
         ob_start();
         $messagesink = $this->redirectMessages();
-        $plugingenerator->runtaskswithintime(time_mock::get_mock_time());
+        $plugingenerator->runtaskswithintime(\core\di::get(\core\clock::class)->time());
         $messages = $messagesink->get_messages();
         $trace = ob_get_clean();
         $messagesink->close();
@@ -760,8 +757,7 @@ final class rules_n_days_test extends advanced_testcase {
         $this->setAdminUser();
         $bdata = self::booking_common_settings_provider();
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         // Setup course, users, booking instance.
         $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
@@ -834,13 +830,13 @@ final class rules_n_days_test extends advanced_testcase {
         $this->assertCount($expected['initialnumberoftasks'], $tasks, 'wrong number of tasks');
 
         if (isset($expected['tasksperoptiondates'])) {
-            $time = time_mock::get_mock_time();
+            $time = \core\di::get(\core\clock::class)->time();
             unset_config('noemailever');
             foreach ($expected['tasksperoptiondates'] as $tasksperoptiondates) {
-                time_mock::set_mock_time(strtotime($tasksperoptiondates['mock_time'], $time));
+                \core\di::get(\core\clock::class)->set_to(strtotime($tasksperoptiondates['mock_time'], $time));
                 ob_start();
                 $messagesink = $this->redirectMessages();
-                $plugingenerator->runtaskswithintime(time_mock::get_mock_time());
+                $plugingenerator->runtaskswithintime(\core\di::get(\core\clock::class)->time());
                 $messages = $messagesink->get_messages();
                 $trace = ob_get_clean();
                 $messagesink->close();
@@ -881,8 +877,7 @@ final class rules_n_days_test extends advanced_testcase {
         $this->setAdminUser();
         $bdata = self::booking_common_settings_provider();
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         // Setup course, users, booking instance.
         $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
@@ -950,13 +945,13 @@ final class rules_n_days_test extends advanced_testcase {
         // After update, expect initial tasks to be doubled.
         $this->assertCount($testdata['initialtasks'] * 2, $tasks, 'wrong number of tasks');
 
-        $time = time_mock::get_mock_time();
-        time_mock::set_mock_time(strtotime('30 June 2050 16:00', $time));
+        $time = \core\di::get(\core\clock::class)->time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('30 June 2050 16:00', $time));
 
         unset_config('noemailever');
         ob_start();
         $messagesink = $this->redirectMessages();
-        $plugingenerator->runtaskswithintime(time_mock::get_mock_time());
+        $plugingenerator->runtaskswithintime(\core\di::get(\core\clock::class)->time());
         $messages = $messagesink->get_messages();
         $trace = ob_get_clean();
         $messagesink->close();

--- a/tests/booking_rules/rules_override_test.php
+++ b/tests/booking_rules/rules_override_test.php
@@ -35,7 +35,6 @@ use mod_booking\booking_rules\rules_info;
 use mod_booking\bo_availability\bo_info;
 use mod_booking\bo_availability\conditions\customform;
 use mod_booking\local\mobile\customformstore;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 
 /**
@@ -55,8 +54,7 @@ final class rules_override_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_rules/rules_responsiblecontact_test.php
+++ b/tests/booking_rules/rules_responsiblecontact_test.php
@@ -27,7 +27,6 @@ namespace mod_booking;
 use advanced_testcase;
 use stdClass;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 
 defined('MOODLE_INTERNAL') || die();
@@ -50,8 +49,7 @@ final class rules_responsiblecontact_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_rules/rules_selflearningcourse_test.php
+++ b/tests/booking_rules/rules_selflearningcourse_test.php
@@ -38,7 +38,6 @@ use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -60,8 +59,7 @@ final class rules_selflearningcourse_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_rules/rules_template_test.php
+++ b/tests/booking_rules/rules_template_test.php
@@ -41,7 +41,6 @@ use mod_booking\form\editteachersforoptiondate_form;
 use stdClass;
 use mod_booking\bo_availability\bo_info;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for booking rules.
@@ -58,8 +57,7 @@ final class rules_template_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_rules/rules_test.php
+++ b/tests/booking_rules/rules_test.php
@@ -36,7 +36,6 @@ use mod_booking\booking_rules\rules_info;
 use mod_booking\bo_availability\bo_info;
 use mod_booking\bo_availability\conditions\customform;
 use mod_booking\local\mobile\customformstore;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 use function PHPUnit\Framework\assertSame;
 
@@ -56,8 +55,7 @@ final class rules_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/booking_rules/rules_waitinglist_notification_test.php
+++ b/tests/booking_rules/rules_waitinglist_notification_test.php
@@ -33,7 +33,6 @@ use local_shopping_cart\shopping_cart;
 use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 
 defined('MOODLE_INTERNAL') || die();
@@ -56,8 +55,7 @@ final class rules_waitinglist_notification_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 
@@ -101,7 +99,7 @@ final class rules_waitinglist_notification_test extends advanced_testcase {
         set_config('timezone', 'Europe/Kyiv');
         set_config('forcetimezone', 'Europe/Kyiv');
 
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
 
         $bdata['cancancelbook'] = 1;
         set_config('cancelationfee', 0, 'local_shopping_cart');
@@ -204,8 +202,8 @@ final class rules_waitinglist_notification_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student3 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student3->id);
@@ -217,8 +215,8 @@ final class rules_waitinglist_notification_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student4 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student4);
         singleton_service::destroy_user($student4->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student4->id);
@@ -260,7 +258,7 @@ final class rules_waitinglist_notification_test extends advanced_testcase {
 
         // In the future we run tasks.
         // No free seats available, so no messages should be send.
-        time_mock::set_mock_time(strtotime('+3 day', time()));
+        \core\di::get(\core\clock::class)->set_to(strtotime('+3 day', time()));
         $sink = $this->redirectMessages();
         ob_start();
         $this->runAdhocTasks();
@@ -538,12 +536,12 @@ final class rules_waitinglist_notification_test extends advanced_testcase {
         $tasks = \core\task\manager::get_adhoc_tasks(\mod_booking\task\send_mail_by_rule_adhoc::class);
         $this->assertNotEmpty($tasks, 'Expected send_mail_by_rule_adhoc adhoc tasks to be created.');
 
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
         if ($data['executealltasks']) {
             // Set this in the far future, so all tasks are being executed.
-            time_mock::set_mock_time(strtotime('+ 30 hours', $time));
+            \core\di::get(\core\clock::class)->set_to(strtotime('+ 30 hours', $time));
         }
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
         $sink = $this->redirectMessages();
         ob_start();
         $plugingenerator->runtaskswithintime($time);

--- a/tests/booking_rules/rules_waitinglist_test.php
+++ b/tests/booking_rules/rules_waitinglist_test.php
@@ -33,7 +33,6 @@ use local_shopping_cart\shopping_cart;
 use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 
 defined('MOODLE_INTERNAL') || die();
@@ -56,8 +55,7 @@ final class rules_waitinglist_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 
@@ -95,9 +93,9 @@ final class rules_waitinglist_test extends advanced_testcase {
         set_config('timezone', 'Europe/Kyiv');
         set_config('forcetimezone', 'Europe/Kyiv');
 
-        time_mock::set_mock_time(strtotime('-4 days', time()));
-        $time = time_mock::get_mock_time();
-        $now = time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('-4 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $this->assertEquals($time, $now);
 
         $bdata['cancancelbook'] = 1;
@@ -200,8 +198,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ALREADYBOOKED, $id);
 
         // Book the student1 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student1);
         singleton_service::destroy_user($student1->id);
         $result = booking_bookit::bookit('option', $settings->id, $student1->id);
@@ -213,8 +211,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student3 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings->id, $student3->id);
@@ -226,8 +224,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student4 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student4);
         singleton_service::destroy_user($student4->id);
         $result = booking_bookit::bookit('option', $settings->id, $student4->id);
@@ -239,8 +237,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Now remove booking of student 2, for a place to free up.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student2);
         $option->user_delete_response($student2->id);
         singleton_service::destroy_booking_option_singleton($option1->id);
@@ -334,9 +332,9 @@ final class rules_waitinglist_test extends advanced_testcase {
         set_config('timezone', 'Europe/Kyiv');
         set_config('forcetimezone', 'Europe/Kyiv');
 
-        time_mock::set_mock_time(strtotime('-4 days', time()));
-        $time = time_mock::get_mock_time();
-        $now = time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('-4 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
+        $now  = \core\di::get(\core\clock::class)->time();
         $this->assertEquals($time, time());
 
         $bdata['cancancelbook'] = 1;
@@ -439,8 +437,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ALREADYBOOKED, $id);
 
         // Book the student2 via waitinglist with intervals.
-        time_mock::set_mock_time(strtotime('-3 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('-3 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student2);
         singleton_service::destroy_user($student2->id);
         $result = booking_bookit::bookit('option', $settings->id, $student2->id);
@@ -452,8 +450,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student3 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings->id, $student3->id);
@@ -465,8 +463,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student4 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student4);
         singleton_service::destroy_user($student4->id);
         $result = booking_bookit::bookit('option', $settings->id, $student4->id);
@@ -479,8 +477,8 @@ final class rules_waitinglist_test extends advanced_testcase {
 
         // Continue as admin.
         $this->setAdminUser();
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         // Update booking.
         $record->id = $option->id;
         $record->cmid = $settings->cmid;
@@ -556,8 +554,8 @@ final class rules_waitinglist_test extends advanced_testcase {
             }
         }
 
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
 
         // Run adhock tasks.
         $sink = $this->redirectMessages();
@@ -605,8 +603,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         // Config settings to reorder waitinaglist.
         set_config('waitinglistshowplaceonwaitinglist', 1, 'booking');
 
-        time_mock::set_mock_time(strtotime('-4 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('-4 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
 
         // User can cancel booking at any time.
         $bdata['cancancelbook'] = 1;
@@ -687,8 +685,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         // Confirm booking as admin.
         $this->setAdminUser();
         // Book the student2 via waitinglist with intervals.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student2);
         singleton_service::destroy_user($student2->id);
         $result = booking_bookit::bookit('option', $settings->id, $student2->id);
@@ -700,8 +698,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student3 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings->id, $student3->id);
@@ -713,8 +711,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student4 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student4);
         singleton_service::destroy_user($student4->id);
         $result = booking_bookit::bookit('option', $settings->id, $student4->id);
@@ -766,8 +764,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $tasks = \core\task\manager::get_adhoc_tasks('\mod_booking\task\send_mail_by_rule_adhoc');
         $this->assertCount(0, $tasks);
 
-        time_mock::set_mock_time(strtotime('now'));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('now'));
+        $time = \core\di::get(\core\clock::class)->time();
         // Reorder the waitinglist - set student 3 as last on waitinglist by updating timemodified to actual time.
         $student3answer = $DB->get_record('booking_answers', [
             'userid' => $student3->id,
@@ -934,8 +932,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ALREADYBOOKED, $id);
 
         // Book the student2 via waitinglist with intervals.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student2);
         singleton_service::destroy_user($student2->id);
         $result = booking_bookit::bookit('option', $settings->id, $student2->id);
@@ -947,8 +945,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student3 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings->id, $student3->id);
@@ -960,8 +958,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student4 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student4);
         singleton_service::destroy_user($student4->id);
         $result = booking_bookit::bookit('option', $settings->id, $student4->id);
@@ -973,8 +971,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student5 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student5);
         singleton_service::destroy_user($student5->id);
         $result = booking_bookit::bookit('option', $settings->id, $student5->id);
@@ -1065,8 +1063,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $DB->update_record('booking_answers', $s6a);
         booking_option::purge_cache_for_answers($settings->id);
 
-        time_mock::set_mock_time(time() + 10);
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(time() + 10);
+        $time = \core\di::get(\core\clock::class)->time();
 
         // Two tasks. One with runtime in the past for user student4.
         // And one for the next user on the list: student2.
@@ -1103,8 +1101,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $runtimedifference = (int)$taskdata[1]->nextruntime - (int)$taskdata[0]->nextruntime;
         $this->assertEquals(1440 * 60, $runtimedifference);
 
-        time_mock::set_mock_time(strtotime('+20 days', time()) + 10);
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+20 days', time()) + 10);
+        $time = \core\di::get(\core\clock::class)->time();
         // We are now 24 days ahead of real current time.
 
         $sink = $this->redirectMessages();
@@ -1119,8 +1117,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         // Finally student2 is next to recieve the message.
         $this->assertEquals($student2->id, $firsttaskdata->userid);
 
-        time_mock::set_mock_time(strtotime('+5 days', time()) + 10);
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+5 days', time()) + 10);
+        $time = \core\di::get(\core\clock::class)->time();
         // We are now 29 days ahead of real current time, so bookingclosingtime is passed.
 
         $sink = $this->redirectMessages();
@@ -1277,8 +1275,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ALREADYBOOKED, $id);
 
         // Book the student2 via waitinglist with intervals.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student2);
         singleton_service::destroy_user($student2->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student2->id);
@@ -1290,8 +1288,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student3 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student3->id);
@@ -1303,8 +1301,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student4 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student4);
         singleton_service::destroy_user($student4->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student4->id);
@@ -1316,8 +1314,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student5 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student5);
         singleton_service::destroy_user($student5->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student5->id);
@@ -1492,7 +1490,7 @@ final class rules_waitinglist_test extends advanced_testcase {
         set_config('timezone', 'Europe/Kyiv');
         set_config('forcetimezone', 'Europe/Kyiv');
 
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
 
         $bdata['cancancelbook'] = 1;
         set_config('cancelationfee', 0, 'local_shopping_cart');
@@ -1637,8 +1635,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student3 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student3);
         singleton_service::destroy_user($student3->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student3->id);
@@ -1650,8 +1648,8 @@ final class rules_waitinglist_test extends advanced_testcase {
         $this->assertEquals(MOD_BOOKING_BO_COND_ONWAITINGLIST, $id);
 
         // Book the student4 via waitinglist.
-        time_mock::set_mock_time(strtotime('+1 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+1 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
         $this->setUser($student4);
         singleton_service::destroy_user($student4->id);
         $result = booking_bookit::bookit('option', $settings1->id, $student4->id);
@@ -1712,8 +1710,8 @@ final class rules_waitinglist_test extends advanced_testcase {
 
         // In the future we run tasks.
         // No free seats available, so no messages should be send.
-        time_mock::set_mock_time(strtotime('+3 day', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+3 day', time()));
+        $time = \core\di::get(\core\clock::class)->time();
 
         $tasks = \core\task\manager::get_adhoc_tasks('\mod_booking\task\send_mail_by_rule_adhoc');
         $sink = $this->redirectMessages();

--- a/tests/bookinghistory_presence_test.php
+++ b/tests/bookinghistory_presence_test.php
@@ -30,7 +30,6 @@ use advanced_testcase;
 use coding_exception;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -53,8 +52,7 @@ final class bookinghistory_presence_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bookinghistory_test.php
+++ b/tests/bookinghistory_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use mod_booking\table\manageusers_table;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class bookinghistory_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bookingoption_filter_test.php
+++ b/tests/bookingoption_filter_test.php
@@ -21,7 +21,6 @@ use context_system;
 use local_wunderbyte_table\filters\types\customfieldfilter;
 use mod_booking\table\bookingoptions_wbtable;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 
 /**
  * Class handling tests for bookinghistory.
@@ -65,8 +64,7 @@ final class bookingoption_filter_test extends advanced_testcase {
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
         // Clear before each test.
         $_GET = [];

--- a/tests/bookitbutton/bookitbutton_bookondetails_test.php
+++ b/tests/bookitbutton/bookitbutton_bookondetails_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use mod_booking\price;
 use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -53,8 +52,7 @@ final class bookitbutton_bookondetails_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/bookitbutton/bookitbutton_test.php
+++ b/tests/bookitbutton/bookitbutton_test.php
@@ -33,7 +33,6 @@ use mod_booking_generator;
 use mod_booking\bo_availability\bo_info;
 use stdClass;
 use context_system;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -56,8 +55,7 @@ final class bookitbutton_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/calendar/calendar_visibility_test.php
+++ b/tests/calendar/calendar_visibility_test.php
@@ -29,7 +29,6 @@ use advanced_testcase;
 use coding_exception;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Calendar visibility tests.
@@ -46,8 +45,7 @@ final class calendar_visibility_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/certificates/certificateconditions/certificate_conditions_test.php
+++ b/tests/certificates/certificateconditions/certificate_conditions_test.php
@@ -605,7 +605,7 @@ final class certificate_conditions_test extends advanced_testcase {
         ]);
         $data->isactive = 1;
         $data->usetemplate = 0;
-        $data->timecreated = time();
+        $data->timecreated  = \core\di::get(\core\clock::class)->time();
         return $data;
     }
 
@@ -632,7 +632,7 @@ final class certificate_conditions_test extends advanced_testcase {
         ]);
         $data->isactive = 1;
         $data->usetemplate = 0;
-        $data->timecreated = time();
+        $data->timecreated  = \core\di::get(\core\clock::class)->time();
         return $data;
     }
 

--- a/tests/checkanswers/checkanswers_test.php
+++ b/tests/checkanswers/checkanswers_test.php
@@ -32,7 +32,6 @@ use mod_booking\bo_availability\bo_info;
 use mod_booking\local\checkanswers\checkanswers;
 use stdClass;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -55,8 +54,7 @@ final class checkanswers_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
         set_config('uselegacymailtemplates', 0, 'booking');
         set_config('unenroluserswithoutaccessareyousure', 1, 'booking');
@@ -100,8 +98,8 @@ final class checkanswers_test extends advanced_testcase {
         $group->name = 'Hidden Group';
         $group->description = 'This group is used for restricting visibility.';
         $group->idnumber = 'group_hidden_001';
-        $group->timecreated = time();
-        $group->timemodified = time();
+        $group->timecreated  = \core\di::get(\core\clock::class)->time();
+        $group->timemodified  = \core\di::get(\core\clock::class)->time();
 
         // Insert the group into the database.
         $groupid = groups_create_group($group);

--- a/tests/checklist_generator_test.php
+++ b/tests/checklist_generator_test.php
@@ -20,7 +20,6 @@ use mod_booking\checklist\checklist_generator;
 use mod_booking\booking_option;
 use advanced_testcase;
 use ReflectionClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Class handling tests for checklist.
@@ -34,8 +33,7 @@ final class checklist_generator_test extends advanced_testcase {
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/circumvent_userprofilecondition_test.php
+++ b/tests/circumvent_userprofilecondition_test.php
@@ -30,7 +30,6 @@ use advanced_testcase;
 use mod_booking\bo_availability\bo_info;
 use mod_booking\local\override_user_field;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -51,8 +50,7 @@ final class circumvent_userprofilecondition_test extends advanced_testcase {
 
     protected function setUp(): void {
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
 
         // Create a test user.

--- a/tests/competency_test/competency_test.php
+++ b/tests/competency_test/competency_test.php
@@ -31,7 +31,6 @@ use core_competency\competency;
 use core_competency\user_competency;
 use stdClass;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for booking rules.
@@ -48,8 +47,7 @@ final class competency_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/confirmation/confirmation_test.php
+++ b/tests/confirmation/confirmation_test.php
@@ -24,7 +24,6 @@ use mod_booking\bo_availability\bo_info;
 use mod_booking\booking_answers\booking_answers;
 use mod_booking\table\manageusers_table;
 use local_wunderbyte_table\wunderbyte_table;
-use tool_mocktesttime\time_mock;
 use mod_booking_generator;
 use context_module;
 
@@ -44,8 +43,7 @@ final class confirmation_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/confirmation/waitinglist_test.php
+++ b/tests/confirmation/waitinglist_test.php
@@ -34,7 +34,6 @@ use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\output\shoppingcart_history_list;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -56,8 +55,7 @@ final class waitinglist_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/course_completion_test.php
+++ b/tests/course_completion_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use completion_completion;
 use context_system;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 use core_competency\api;
 use core_competency\competency;
 
@@ -56,8 +55,7 @@ final class course_completion_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/event/events_test.php
+++ b/tests/event/events_test.php
@@ -28,7 +28,6 @@ namespace mod_booking;
 use advanced_testcase;
 use context_course;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for forum events.
@@ -45,8 +44,7 @@ final class events_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/filters/available_places_test.php
+++ b/tests/filters/available_places_test.php
@@ -25,7 +25,6 @@ use mod_booking\bo_availability\bo_info;
 use mod_booking\singleton_service;
 use mod_booking\table\bookingoptions_wbtable;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for Booking
@@ -45,8 +44,7 @@ final class available_places_test extends \advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
         $_POST = [];
         $_GET = [];

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -52,7 +52,6 @@ use mod_booking\bo_availability\conditions\userprofilefield_1_default;
 use mod_booking\bo_availability\conditions\userprofilefield_2_custom;
 use mod_booking\settings\optionformconfig\optionformconfig_info;
 use mod_booking\enrollink;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -116,7 +115,7 @@ class mod_booking_generator extends testing_module_generator {
         // Shopping cart.
         cartstore::reset();
         // Time mock.
-        time_mock::reset_mock_time();
+        \core\di::set(\core\clock::class, new \core\system_clock());
         // Clean up globals after each test.
         $_GET = [];
         $_POST = [];
@@ -416,7 +415,7 @@ class mod_booking_generator extends testing_module_generator {
 
         $record = (object) $record;
 
-        $record->timemodified = time();
+        $record->timemodified  = \core\di::get(\core\clock::class)->time();
         $record->usermodified = $USER->id;
 
         $record->id = $DB->insert_record('booking_subbooking_options', $record);

--- a/tests/ical/ical_test.php
+++ b/tests/ical/ical_test.php
@@ -22,7 +22,6 @@ use stdClass;
 use mod_booking_generator;
 use mod_booking\option\fields_info;
 use mod_booking\bo_availability\bo_info;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for ical.
@@ -39,8 +38,7 @@ final class ical_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/importer/booking_importer_test.php
+++ b/tests/importer/booking_importer_test.php
@@ -33,7 +33,6 @@ use mod_booking\price;
 use mod_booking_generator;
 use stdClass;
 use mod_booking\importer\bookingoptionsimporter;
-use tool_mocktesttime\time_mock;
 
 /**
  * Class handling tests for booking importer.
@@ -50,8 +49,7 @@ final class booking_importer_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -26,7 +26,6 @@
 
 namespace mod_booking;
 
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -53,8 +52,7 @@ final class lib_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/multiple_bookings/booking_test.php
+++ b/tests/multiple_bookings/booking_test.php
@@ -25,7 +25,6 @@ use mod_booking\booking_answers\booking_answers;
 use mod_booking\table\manageusers_table;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking_generator;
-use tool_mocktesttime\time_mock;
 use local_shopping_cart\shopping_cart;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart_generator;
@@ -50,8 +49,7 @@ final class booking_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 
@@ -100,8 +98,7 @@ final class booking_test extends advanced_testcase {
             'cancancelbook' => 0,
         ]);
 
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
 
         return [
             'course' => $course,
@@ -260,10 +257,10 @@ final class booking_test extends advanced_testcase {
         $this->assertSame(MOD_BOOKING_STATUSPARAM_BOOKED, (int) $answer->waitinglist);
 
         // We advance the time and check bo_availabilty to see if expectation are met.
-        $time = time_mock::get_mock_time();
+        $time = \core\di::get(\core\clock::class)->time();
         $this->assertSame(time(), $time);
-        time_mock::set_mock_time($time + $clockforwardshift); // Jump N seconds into the future.
-        $future = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to($time + $clockforwardshift); // Jump N seconds into the future.
+        $future = \core\di::get(\core\clock::class)->time();
         $this->assertEquals(time(), $future);
 
         // No we are in future, we will check the booking option availability.

--- a/tests/optiondates/optiondate_answer_test.php
+++ b/tests/optiondates/optiondate_answer_test.php
@@ -28,7 +28,6 @@ namespace mod_booking;
 
 use advanced_testcase;
 use mod_booking\local\optiondates\optiondate_answer;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -44,8 +43,7 @@ final class optiondate_answer_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/output/booking_timezone_test.php
+++ b/tests/output/booking_timezone_test.php
@@ -23,7 +23,6 @@ use mod_booking\singleton_service;
 use mod_booking\table\bookingoptions_wbtable;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for booking option showdates rendering with user timezones.
@@ -40,8 +39,7 @@ final class booking_timezone_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/output/description/description_ical_calendarevent_test.php
+++ b/tests/output/description/description_ical_calendarevent_test.php
@@ -23,7 +23,6 @@ use mod_booking_generator;
 use mod_booking\singleton_service;
 use context_system;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * Tests for Booking
@@ -40,8 +39,7 @@ final class description_ical_calendarevent_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/reportbuilder/reportbuilder_test.php
+++ b/tests/reportbuilder/reportbuilder_test.php
@@ -31,7 +31,6 @@ use mod_booking\reportbuilder\datasource\booking_answers_datasource;
 use mod_booking\reportbuilder\datasource\booking_options_datasource;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -90,8 +89,7 @@ final class reportbuilder_test extends core_reportbuilder_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/settings/optionformconfig_info_test.php
+++ b/tests/settings/optionformconfig_info_test.php
@@ -30,7 +30,6 @@ use advanced_testcase;
 use context_course;
 use context_system;
 use mod_booking\settings\optionformconfig\optionformconfig_info;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -46,8 +45,7 @@ final class optionformconfig_info_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shopping_cart/shopping_cart_cancellation_with_price_test.php
+++ b/tests/shopping_cart/shopping_cart_cancellation_with_price_test.php
@@ -35,7 +35,6 @@ use local_shopping_cart\shopping_cart_history;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart\form\modal_cancel_all_addcredit;
 use local_shopping_cart\shopping_cart_credits;
-use tool_mocktesttime\time_mock;
 use mod_booking\booking_rules\booking_rules;
 use mod_booking\booking_rules\rules_info;
 
@@ -59,8 +58,7 @@ final class shopping_cart_cancellation_with_price_test extends advanced_testcase
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shopping_cart/shopping_cart_installment_test.php
+++ b/tests/shopping_cart/shopping_cart_installment_test.php
@@ -36,7 +36,6 @@ use mod_booking\bo_availability\bo_info;
 use local_shopping_cart\shopping_cart;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart_generator;
-use tool_mocktesttime\time_mock;
 use mod_booking\booking_rules\booking_rules;
 use mod_booking\booking_rules\rules_info;
 
@@ -63,8 +62,7 @@ final class shopping_cart_installment_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
         set_config('country', 'AT');
         /** @var \core_payment_generator $generator */
@@ -74,8 +72,8 @@ final class shopping_cart_installment_test extends advanced_testcase {
         $record->accountid = $this->account->get('id');
         $record->gateway = 'paypal';
         $record->enabled = 1;
-        $record->timecreated = time();
-        $record->timemodified = time();
+        $record->timecreated  = \core\di::get(\core\clock::class)->time();
+        $record->timemodified  = \core\di::get(\core\clock::class)->time();
 
         $config = new stdClass();
         $config->environment = 'sandbox';
@@ -117,8 +115,8 @@ final class shopping_cart_installment_test extends advanced_testcase {
             return;
         }
 
-        time_mock::set_mock_time(strtotime('-4 days', time()));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('-4 days', time()));
+        $time = \core\di::get(\core\clock::class)->time();
 
         // Validate payment account if it has a config.
         $record1 = $DB->get_record('payment_accounts', ['id' => $this->account->get('id')]);
@@ -295,8 +293,8 @@ final class shopping_cart_installment_test extends advanced_testcase {
 
         // Reset cart and move +2 day forward - we should pay 1st installment.
         cartstore::reset();
-        time_mock::set_mock_time(strtotime('+2 days', $time));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+2 days', $time));
+        $time = \core\di::get(\core\clock::class)->time();
         // Validate count of tasks.
         $sink = $this->redirectMessages();
         $tasks = \core\task\manager::get_adhoc_tasks('\mod_booking\task\send_mail_by_rule_adhoc');
@@ -346,8 +344,8 @@ final class shopping_cart_installment_test extends advanced_testcase {
 
         // Reset cart and move +2 day forward - we should pay 2nd installment.
         cartstore::reset();
-        time_mock::set_mock_time(strtotime('+2 days', $time));
-        $time = time_mock::get_mock_time();
+        \core\di::get(\core\clock::class)->set_to(strtotime('+2 days', $time));
+        $time = \core\di::get(\core\clock::class)->time();
         // Validate count of tasks.
         $sink = $this->redirectMessages();
         $tasks = \core\task\manager::get_adhoc_tasks('\mod_booking\task\send_mail_by_rule_adhoc');

--- a/tests/shopping_cart/shopping_cart_test.php
+++ b/tests/shopping_cart/shopping_cart_test.php
@@ -36,7 +36,6 @@ use mod_booking\local\mobile\customformstore;
 use local_shopping_cart\local\cartstore;
 use local_shopping_cart_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 use mod_booking\booking_rules\booking_rules;
 use mod_booking\booking_rules\rules_info;
 
@@ -60,8 +59,7 @@ final class shopping_cart_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/allbookingoptions_test.php
+++ b/tests/shortcodes/allbookingoptions_test.php
@@ -32,7 +32,6 @@ use context_system;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -55,8 +54,7 @@ final class allbookingoptions_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/arguments_test.php
+++ b/tests/shortcodes/arguments_test.php
@@ -33,7 +33,6 @@ use context_system;
 use local_wunderbyte_table\external\load_data;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 /**
  * This test tests the functionality of some arguments.
@@ -53,8 +52,7 @@ final class arguments_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/bulkoperations_test.php
+++ b/tests/shortcodes/bulkoperations_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class bulkoperations_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/cfincludeandcustomfield_test.php
+++ b/tests/shortcodes/cfincludeandcustomfield_test.php
@@ -23,7 +23,6 @@ use context_system;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -60,8 +59,7 @@ final class cfincludeandcustomfield_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/courselist_test.php
+++ b/tests/shortcodes/courselist_test.php
@@ -32,7 +32,6 @@ use context_system;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -55,8 +54,7 @@ final class courselist_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/linkbacktocourse_test.php
+++ b/tests/shortcodes/linkbacktocourse_test.php
@@ -31,7 +31,6 @@ use coding_exception;
 use context_course;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -54,8 +53,7 @@ final class linkbacktocourse_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/mycourselist_test.php
+++ b/tests/shortcodes/mycourselist_test.php
@@ -33,7 +33,6 @@ use context_user;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -56,8 +55,7 @@ final class mycourselist_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/shortcodes/recommendedin_test.php
+++ b/tests/shortcodes/recommendedin_test.php
@@ -33,7 +33,6 @@ use context_system;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking_generator;
 use stdClass;
-use tool_mocktesttime\time_mock;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
@@ -56,8 +55,7 @@ final class recommendedin_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 

--- a/tests/task/send_reminder_mails_test.php
+++ b/tests/task/send_reminder_mails_test.php
@@ -34,7 +34,6 @@ use mod_booking_generator;
 use context_system;
 use stdClass;
 use core\event\notification_sent;
-use tool_mocktesttime\time_mock;
 
 /**
  * Class handling tests for booking reminder mails.
@@ -51,8 +50,7 @@ final class send_reminder_mails_test extends advanced_testcase {
     public function setUp(): void {
         parent::setUp();
         $this->resetAfterTest();
-        time_mock::init();
-        time_mock::set_mock_time(strtotime('now'));
+        $this->mock_clock_with_frozen(time());
         singleton_service::destroy_instance();
     }
 


### PR DESCRIPTION
This is a part of attempting remove dependencies in tests raised as part of #1430

Using core DI container instead of tool_mocktesttime