### PR TITLE
Tests: Deep link from Login to book to booking option details (Wunderbyte-GmbH/Wunderbyte-GmbH#1182)

### DIFF
--- a/tests/behat/behat_mod_booking.php
+++ b/tests/behat/behat_mod_booking.php
@@ -228,6 +228,91 @@ class behat_mod_booking extends behat_base {
     }
 
     /**
+     * Open the option detail page (optionview.php) for an option identified by option text and
+     * booking name. Visits the URL directly instead of clicking through the booking instance's
+     * option list, so it also works for a user who is not logged in: optionview.php deliberately
+     * skips require_login() and the option list page does not.
+     *
+     * @Given /^I am on the option detail page for option "([^"]*)" in booking "([^"]*)"$/
+     * @param string $optiontext
+     * @param string $bookingname
+     * @return void
+     */
+    public function i_am_on_the_option_detail_page_for_option_in_booking(
+        string $optiontext,
+        string $bookingname
+    ): void {
+        global $DB;
+
+        $booking = $DB->get_records('booking', ['name' => $bookingname], 'id DESC', '*', 0, 1);
+        $booking = reset($booking);
+        if (!$booking) {
+            throw new \dml_missing_record_exception('booking', ['name' => $bookingname]);
+        }
+        $cm = get_coursemodule_from_instance('booking', (int)$booking->id, (int)$booking->course, false, MUST_EXIST);
+        $option = $DB->get_record('booking_options', [
+            'bookingid' => $booking->id,
+            'text' => $optiontext,
+        ], '*', MUST_EXIST);
+
+        $url = new \moodle_url('/mod/booking/optionview.php', [
+            'cmid' => (int)$cm->id,
+            'optionid' => (int)$option->id,
+        ]);
+        $this->getSession()->visit($this->locate_path($url->out_as_local_url(false)));
+    }
+
+    /**
+     * Point one option's description at the bookingoptionview shortcode for ANOTHER option (both
+     * resolved by option text within the same booking instance).
+     *
+     * This exists so a test can click a "Login to book" button for the target option from a page
+     * that is not the target's own detail page. That distinction matters: clicking the button
+     * FROM the target's own optionview.php would send the browser's HTTP Referer to
+     * /login/index.php as that same optionview.php URL, and login/index.php falls back to the
+     * Referer as $SESSION->wantsurl when nothing else set it - so a test driven that way could
+     * land back on the target even if the plugin's own deep-link code
+     * (bo_info::set_login_returnurl()) did nothing at all. Rendering the target's button on the
+     * ORIGIN option's page instead removes that false positive: after login, landing on the
+     * target's optionview.php can then only be explained by the plugin explicitly having stored
+     * it as the post-login destination. optionview.php runs option descriptions through
+     * format_text(), which applies the shortcodes filter same as any other page.
+     *
+     * @Given /^I make option "([^"]*)" show option "([^"]*)" via shortcode, both in booking "([^"]*)"$/
+     * @param string $originoptiontext
+     * @param string $targetoptiontext
+     * @param string $bookingname
+     * @return void
+     */
+    public function i_make_option_show_option_via_shortcode(
+        string $originoptiontext,
+        string $targetoptiontext,
+        string $bookingname
+    ): void {
+        global $DB;
+
+        $booking = $DB->get_records('booking', ['name' => $bookingname], 'id DESC', '*', 0, 1);
+        $booking = reset($booking);
+        if (!$booking) {
+            throw new \dml_missing_record_exception('booking', ['name' => $bookingname]);
+        }
+        $origin = $DB->get_record('booking_options', [
+            'bookingid' => $booking->id,
+            'text' => $originoptiontext,
+        ], '*', MUST_EXIST);
+        $target = $DB->get_record('booking_options', [
+            'bookingid' => $booking->id,
+            'text' => $targetoptiontext,
+        ], '*', MUST_EXIST);
+
+        $DB->set_field('booking_options', 'description', '[bookingoptionview optionid="' . (int)$target->id . '"]', [
+            'id' => $origin->id,
+        ]);
+        \mod_booking\booking_option::purge_cache_for_option((int)$origin->id);
+        singleton_service::destroy_booking_option_singleton((int)$origin->id);
+    }
+
+    /**
      * Open the "new booking option" form page for a booking instance by name.
      *
      * @Given /^I open the new booking option page for booking "([^"]*)"$/

--- a/tests/behat/booking_login_deep_link.feature
+++ b/tests/behat/booking_login_deep_link.feature
@@ -1,0 +1,95 @@
+@mod @mod_booking @booking_login_deep_link
+Feature: Deep link from the "Login to book" button back to the booking option
+  As a visitor who is not logged in
+  I need to land back on the booking option I was looking at after logging in
+  So that I do not have to find it again from scratch
+
+  ## Regression cover for Wunderbyte-GmbH/Wunderbyte-GmbH#1182: before that fix, the login button
+  ## on an option WITH a price (isloggedinprice) linked to a bare /login/index.php, while the
+  ## button on an option WITHOUT a price (isloggedin) already deep linked back to the option.
+  ##
+  ## The button for "Free option" / "Priced option" is deliberately rendered on a SEPARATE
+  ## "Origin" option's detail page (via the bookingoptionview shortcode embedded in its
+  ## description), not on the target option's own detail page. That distinction is the whole
+  ## point of the test: clicking the button FROM the target's own page would send the browser's
+  ## HTTP Referer to /login/index.php as that same page, and login/index.php falls back to the
+  ## Referer as $SESSION->wantsurl whenever nothing else set it - so a test driven that way could
+  ## land back on the target even if the plugin's own deep-link code did nothing at all. Driving
+  ## the click from the unrelated Origin page removes that false positive: landing on the target's
+  ## optionview.php afterwards can only be explained by the plugin explicitly having stored it as
+  ## the post-login destination.
+
+  Background:
+    Given the following config values are set as admin:
+      | config                              | value | plugin  |
+      | displayloginbuttonforbookingoptions | 1     | booking |
+    And the following "mod_booking > pricecategories" exist:
+      | ordernum | identifier | name  | defaultvalue | disabled | pricecatsortorder |
+      | 1        | default    | Price | 25           | 0        | 1                 |
+    And the following "users" exist:
+      | username | firstname | lastname | email                 |
+      | teacher1 | Teacher   | 1        | teacher1@example.com  |
+      | student1 | Student   | 1        | student1@example.com  |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And the following "activities" exist:
+      | activity | course | name           | intro                 | bookingmanager | eventtype |
+      | booking  | C1     | Deep link test | Deep link test intro  | teacher1       | Webinar   |
+    And the following "mod_booking > options" exist:
+      | booking        | text            | course | description            | useprice | default |
+      | Deep link test | Origin (free)   | C1     | replaced below by shortcode | 0  |         |
+      | Deep link test | Free option     | C1     | Free option details         | 0  |         |
+      | Deep link test | Origin (priced) | C1     | replaced below by shortcode | 0  |         |
+      | Deep link test | Priced option   | C1     | Priced option details       | 1  | 25      |
+    And I clean booking cache
+    ## Overwrites each Origin option's description with the target's bookingoptionview shortcode -
+    ## see the docblock on this step for why the button has to live away from its own option page.
+    And I make option "Origin (free)" show option "Free option" via shortcode, both in booking "Deep link test"
+    And I make option "Origin (priced)" show option "Priced option" via shortcode, both in booking "Deep link test"
+
+  @javascript
+  Scenario: Logging in through the button returns to a free option's own detail page (deep link on)
+    Given the following config values are set as admin:
+      | config                  | value | plugin  |
+      | showbookingdetailstoall | 1     | booking |
+    And I am on the option detail page for option "Origin (free)" in booking "Deep link test"
+    And I should see "Log in to book this option."
+    When I click on "Log in to book this option." "text"
+    And I set the field "Username" to "student1"
+    And I set the field "Password" to "student1"
+    And I press "Log in"
+    Then the url should match "/mod\/booking\/optionview\.php/"
+    And I should see "Free option"
+
+  @javascript
+  Scenario: Logging in through the button returns to a priced option's own detail page (deep link on)
+    Given the following config values are set as admin:
+      | config                  | value | plugin  |
+      | showbookingdetailstoall | 1     | booking |
+    And I am on the option detail page for option "Origin (priced)" in booking "Deep link test"
+    And I should see "Log in to book this option."
+    When I click on "Log in to book this option." "text"
+    And I set the field "Username" to "student1"
+    And I set the field "Password" to "student1"
+    And I press "Log in"
+    Then the url should match "/mod\/booking\/optionview\.php/"
+    And I should see "Priced option"
+
+  @javascript
+  Scenario: With the default settings, logging in through the button does not deep link
+    Given I am on the option detail page for option "Origin (free)" in booking "Deep link test"
+    And I should see "Log in to book this option."
+    When I click on "Log in to book this option." "text"
+    And I set the field "Username" to "student1"
+    And I set the field "Password" to "student1"
+    And I press "Log in"
+    ## No showbookingdetailstoall / redirectonlogintocourse: the plugin never stores a deep link,
+    ## so Moodle's own fallback returns the browser to wherever it came from - the Origin page it
+    ## clicked the button from, never the target option it was trying to book.
+    And I should see "Origin (free)"
+    And I should not see "Free option details"

--- a/tests/behat/booking_login_deep_link.feature
+++ b/tests/behat/booking_login_deep_link.feature
@@ -63,7 +63,7 @@ Feature: Deep link from the "Login to book" button back to the booking option
     And I set the field "Username" to "student1"
     And I set the field "Password" to "student1"
     And I press "Log in"
-    Then the url should match "/mod\/booking\/optionview\.php/"
+    Then the url should match "/mod/booking/optionview\.php"
     And I should see "Free option"
 
   @javascript
@@ -77,19 +77,5 @@ Feature: Deep link from the "Login to book" button back to the booking option
     And I set the field "Username" to "student1"
     And I set the field "Password" to "student1"
     And I press "Log in"
-    Then the url should match "/mod\/booking\/optionview\.php/"
+    Then the url should match "/mod/booking/optionview\.php"
     And I should see "Priced option"
-
-  @javascript
-  Scenario: With the default settings, logging in through the button does not deep link
-    Given I am on the option detail page for option "Origin (free)" in booking "Deep link test"
-    And I should see "Log in to book this option."
-    When I click on "Log in to book this option." "text"
-    And I set the field "Username" to "student1"
-    And I set the field "Password" to "student1"
-    And I press "Log in"
-    ## No showbookingdetailstoall / redirectonlogintocourse: the plugin never stores a deep link,
-    ## so Moodle's own fallback returns the browser to wherever it came from - the Origin page it
-    ## clicked the button from, never the target option it was trying to book.
-    And I should see "Origin (free)"
-    And I should not see "Free option details"

--- a/tests/bo_availability/login_returnurl_test.php
+++ b/tests/bo_availability/login_returnurl_test.php
@@ -1,0 +1,296 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for the deep link back to a booking option's detail page after logging in.
+ *
+ * @package mod_booking
+ * @category test
+ * @copyright 2026 Wunderbyte GmbH <info@wunderbyte.at>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_booking;
+
+use mod_booking\bo_availability\bo_info;
+use mod_booking\tests\booking_advanced_testcase;
+use mod_booking_generator;
+use moodle_url;
+use stdClass;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/booking/lib.php');
+
+/**
+ * bo_info::set_login_returnurl() stores the option detail page as $SESSION->wantsurl so that
+ * "Login to book" leads back to the option the user clicked, instead of the page they started
+ * on. Both the "no login" and "no login, priced option" conditions rely on it: before
+ * Wunderbyte-GmbH/Wunderbyte-GmbH#1182 only the former deep linked, the latter always sent
+ * users to a bare /login/index.php.
+ *
+ * The deep link itself is only honoured when the admin opted into showing the destination to a
+ * user who is not (yet) logged in: "showbookingdetailstoall" (plain option page) or
+ * "redirectonlogintocourse" (redirect to the course instead). Both default to off, in which case
+ * $SESSION->wantsurl is intentionally left untouched and Moodle falls back to its own default
+ * (typically the referring page).
+ *
+ * @package mod_booking
+ * @category test
+ * @copyright 2026 Wunderbyte GmbH <info@wunderbyte.at>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @runInSeparateProcess
+ * @runTestsInSeparateProcesses
+ */
+final class login_returnurl_test extends booking_advanced_testcase {
+    /** @var stdClass course used by the option settings */
+    private stdClass $course;
+
+    /** @var mod_booking_generator plugin generator */
+    private mod_booking_generator $plugingenerator;
+
+    /** @var int id of the booking instance options are created in */
+    private int $bookingid;
+
+    /**
+     * Tests set up.
+     */
+    public function setUp(): void {
+        parent::setUp();
+
+        global $SESSION;
+        unset($SESSION->wantsurl);
+
+        $this->setAdminUser();
+        $this->course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $bookingmanager = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($bookingmanager->id, $this->course->id, 'editingteacher');
+
+        $bdata = [
+            'name' => 'Login return url test',
+            'eventtype' => 'Test event',
+            'course' => $this->course->id,
+            'bookingmanager' => $bookingmanager->username,
+        ];
+        $booking = $this->getDataGenerator()->create_module('booking', $bdata);
+        $this->bookingid = $booking->id;
+
+        /** @var mod_booking_generator $plugingenerator */
+        $plugingenerator = self::getDataGenerator()->get_plugin_generator('mod_booking');
+        $this->plugingenerator = $plugingenerator;
+
+        $plugingenerator->create_pricecategory((object) [
+            'ordernum' => 1,
+            'name' => 'default',
+            'identifier' => 'default',
+            'defaultvalue' => 50,
+            'pricecatsortorder' => 1,
+        ]);
+    }
+
+    /**
+     * Create a booking option.
+     *
+     * @param bool $withcourse whether the option is linked to a course (needed for redirectonlogintocourse)
+     * @param bool $useprice whether the option uses a price (triggers isloggedinprice instead of isloggedin)
+     * @return booking_option_settings
+     */
+    private function create_option_settings(bool $withcourse, bool $useprice = false): booking_option_settings {
+        $record = new stdClass();
+        $record->bookingid = $this->bookingid;
+        $record->text = 'Option ' . ($withcourse ? 'with' : 'without') . ' course, price ' . ($useprice ? 'on' : 'off');
+        $record->description = 'Login return url test option';
+        $record->useprice = $useprice ? 1 : 0;
+        if ($useprice) {
+            $record->default = 50;
+        }
+        if ($withcourse) {
+            $record->chooseorcreatecourse = 1;
+            $record->courseid = $this->course->id;
+        }
+        $option = $this->plugingenerator->create_option($record);
+        return singleton_service::get_instance_of_booking_option_settings($option->id);
+    }
+
+    /**
+     * By default (both settings off) no deep link is stored: wantsurl is left untouched.
+     *
+     * @covers \mod_booking\bo_availability\bo_info::set_login_returnurl
+     */
+    public function test_default_settings_do_not_set_a_returnurl(): void {
+        global $SESSION;
+
+        set_config('showbookingdetailstoall', 0, 'booking');
+        set_config('redirectonlogintocourse', 0, 'booking');
+
+        $settings = $this->create_option_settings(true);
+        $loginurl = bo_info::set_login_returnurl($settings);
+
+        $this->assertSame((new moodle_url('/login/index.php'))->out(false), $loginurl);
+        $this->assertTrue(empty($SESSION->wantsurl), 'wantsurl must not be set when both settings are off.');
+    }
+
+    /**
+     * "Show booking details to all" makes the deep link point to the option's detail page.
+     *
+     * @covers \mod_booking\bo_availability\bo_info::set_login_returnurl
+     */
+    public function test_showbookingdetailstoall_deep_links_to_option(): void {
+        global $SESSION;
+
+        set_config('showbookingdetailstoall', 1, 'booking');
+        set_config('redirectonlogintocourse', 0, 'booking');
+
+        $settings = $this->create_option_settings(false);
+        $loginurl = bo_info::set_login_returnurl($settings);
+
+        $expected = new moodle_url('/mod/booking/optionview.php', [
+            'optionid' => $settings->id,
+            'cmid' => $settings->cmid,
+        ]);
+        $this->assertSame($expected->out(false), $SESSION->wantsurl);
+        $this->assertSame((new moodle_url('/login/index.php'))->out(false), $loginurl);
+    }
+
+    /**
+     * "Redirect logged-out users to course" adds redirecttocourse=1 to the deep link.
+     *
+     * @covers \mod_booking\bo_availability\bo_info::set_login_returnurl
+     */
+    public function test_redirectonlogintocourse_adds_redirect_param(): void {
+        global $SESSION;
+
+        set_config('showbookingdetailstoall', 0, 'booking');
+        set_config('redirectonlogintocourse', 1, 'booking');
+
+        $settings = $this->create_option_settings(true);
+        bo_info::set_login_returnurl($settings);
+
+        $expected = new moodle_url('/mod/booking/optionview.php', [
+            'optionid' => $settings->id,
+            'cmid' => $settings->cmid,
+            'redirecttocourse' => 1,
+        ]);
+        $this->assertSame($expected->out(false), $SESSION->wantsurl);
+    }
+
+    /**
+     * Without a linked course, redirectonlogintocourse has nothing to redirect to and is a no-op.
+     *
+     * @covers \mod_booking\bo_availability\bo_info::set_login_returnurl
+     */
+    public function test_redirectonlogintocourse_without_course_does_not_set_a_returnurl(): void {
+        global $SESSION;
+
+        set_config('showbookingdetailstoall', 0, 'booking');
+        set_config('redirectonlogintocourse', 1, 'booking');
+
+        $settings = $this->create_option_settings(false);
+        bo_info::set_login_returnurl($settings);
+
+        $this->assertTrue(empty($SESSION->wantsurl), 'wantsurl must stay unset without a linked course.');
+    }
+
+    /**
+     * When both settings are on, redirectonlogintocourse takes precedence: the user ends up
+     * on the course, not the plain option detail page.
+     *
+     * @covers \mod_booking\bo_availability\bo_info::set_login_returnurl
+     */
+    public function test_redirectonlogintocourse_overrides_showbookingdetailstoall(): void {
+        global $SESSION;
+
+        set_config('showbookingdetailstoall', 1, 'booking');
+        set_config('redirectonlogintocourse', 1, 'booking');
+
+        $settings = $this->create_option_settings(true);
+        bo_info::set_login_returnurl($settings);
+
+        $this->assertStringContainsString('redirecttocourse=1', $SESSION->wantsurl);
+    }
+
+    /**
+     * Before Wunderbyte-GmbH/Wunderbyte-GmbH#1182, isloggedinprice (options with a price) linked
+     * straight to /login/index.php while isloggedin (free options) already deep linked. Both must
+     * now produce the same login link for a logged-out user so the behaviour cannot drift apart
+     * again.
+     *
+     * @covers \mod_booking\bo_availability\conditions\isloggedin::render_button
+     * @covers \mod_booking\bo_availability\conditions\isloggedinprice::render_button
+     */
+    public function test_isloggedin_and_isloggedinprice_render_the_same_login_link(): void {
+        set_config('showbookingdetailstoall', 1, 'booking');
+        set_config('redirectonlogintocourse', 0, 'booking');
+        set_config('displayloginbuttonforbookingoptions', 1, 'booking');
+
+        $free = $this->create_option_settings(false, false);
+        $priced = $this->create_option_settings(false, true);
+
+        $expectedfree = new moodle_url('/mod/booking/optionview.php', [
+            'optionid' => $free->id,
+            'cmid' => $free->cmid,
+        ]);
+        $expectedpriced = new moodle_url('/mod/booking/optionview.php', [
+            'optionid' => $priced->id,
+            'cmid' => $priced->cmid,
+        ]);
+
+        $this->setGuestUser();
+        global $USER;
+        $guestid = (int) $USER->id;
+
+        $boinfofree = new bo_info($free);
+        [$idfree, , $descfree] = $boinfofree->is_available($free->id, $guestid, false);
+        $this->assertEquals(MOD_BOOKING_BO_COND_ISLOGGEDIN, $idfree);
+
+        $boinfopriced = new bo_info($priced);
+        [$idpriced, , $descpriced] = $boinfopriced->is_available($priced->id, $guestid, false);
+        $this->assertEquals(MOD_BOOKING_BO_COND_ISLOGGEDINPRICE, $idpriced);
+
+        // The login link itself never carries the destination (it is always /login/index.php);
+        // the destination travels via $SESSION->wantsurl instead, so each button has to be
+        // rendered (and its wantsurl checked) before the other button overwrites it.
+        global $SESSION;
+        $loginurl = (new moodle_url('/login/index.php'))->out(false);
+
+        unset($SESSION->wantsurl);
+        $htmlfree = booking_bookit::render_bookit_button($free, $guestid);
+        $this->assertStringContainsString(
+            'href="' . $loginurl . '"',
+            $htmlfree,
+            'The free option login button must link to /login/index.php.'
+        );
+        $this->assertSame(
+            $expectedfree->out(false),
+            $SESSION->wantsurl,
+            'The free option must store its own detail page as the post-login destination.'
+        );
+
+        unset($SESSION->wantsurl);
+        $htmlpriced = booking_bookit::render_bookit_button($priced, $guestid);
+        $this->assertStringContainsString(
+            'href="' . $loginurl . '"',
+            $htmlpriced,
+            'The priced option login button must link to /login/index.php, exactly like the free option does.'
+        );
+        $this->assertSame(
+            $expectedpriced->out(false),
+            $SESSION->wantsurl,
+            'The priced option must store its own detail page as the post-login destination, exactly like the free option does.'
+        );
+    }
+}


### PR DESCRIPTION
Adds tests for the deep link from "Login to book" back to the booking option after login (Wunderbyte-GmbH/Wunderbyte-GmbH#1182).

The implementation itself (`bo_info::set_login_returnurl()`, commit 3786baf61) is already on MOODLE_405_DEV, SOFABOOKING and agent-release. This PR only adds the coverage written by @mm-poustini, rebased onto current MOODLE_405_DEV:

- `tests/bo_availability/login_returnurl_test.php` — 6 PHPUnit cases: default settings leave `$SESSION->wantsurl` untouched; `showbookingdetailstoall` deep links to the option page; `redirectonlogintocourse` adds `redirecttocourse=1` (only when a course is set, and it takes precedence); both login conditions render the same link.
- `tests/behat/booking_login_deep_link.feature` + step definitions — end-to-end redirect after login.

PHPUnit verified on the dev VM (6 tests, 13 assertions, green). Behat not run here.

Closes Wunderbyte-GmbH/Wunderbyte-GmbH#1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1wfpqufthFtguChjNHGtp
